### PR TITLE
fix(deno): support Deno 1.4.0 strict type checks

### DIFF
--- a/deno_dist/compile-string.ts
+++ b/deno_dist/compile-string.ts
@@ -2,8 +2,8 @@ import Parse from "./parse.ts";
 
 /* TYPES */
 
-import { EtaConfig } from "./config.ts";
-import { AstObject } from "./parse.ts";
+import type { EtaConfig } from "./config.ts";
+import type { AstObject } from "./parse.ts";
 
 /* END TYPES */
 

--- a/deno_dist/compile.ts
+++ b/deno_dist/compile.ts
@@ -4,8 +4,8 @@ import EtaErr from "./err.ts";
 
 /* TYPES */
 
-import { EtaConfig, PartialConfig } from "./config.ts";
-import { CallbackFn } from "./file-handlers.ts";
+import type { EtaConfig, PartialConfig } from "./config.ts";
+import type { CallbackFn } from "./file-handlers.ts";
 import { getAsyncFunctionConstructor } from "./polyfills.ts";
 export type TemplateFunction = (
   data: object,

--- a/deno_dist/config.ts
+++ b/deno_dist/config.ts
@@ -4,8 +4,8 @@ import EtaErr from "./err.ts";
 
 /* TYPES */
 
-import { TemplateFunction } from "./compile.ts";
-import { Cacher } from "./storage.ts";
+import type { TemplateFunction } from "./compile.ts";
+import type { Cacher } from "./storage.ts";
 
 type trimConfig = "nl" | "slurp" | false;
 

--- a/deno_dist/containers.ts
+++ b/deno_dist/containers.ts
@@ -2,7 +2,7 @@ import { Cacher } from "./storage.ts";
 
 /* TYPES */
 
-import { TemplateFunction } from "./compile.ts";
+import type { TemplateFunction } from "./compile.ts";
 
 /* END TYPES */
 

--- a/deno_dist/file-handlers.ts
+++ b/deno_dist/file-handlers.ts
@@ -9,8 +9,12 @@ import { promiseImpl } from "./polyfills.ts";
 
 /* TYPES */
 
-import { EtaConfig, PartialConfig, EtaConfigWithFilename } from "./config.ts";
-import { TemplateFunction } from "./compile.ts";
+import type {
+  EtaConfig,
+  PartialConfig,
+  EtaConfigWithFilename,
+} from "./config.ts";
+import type { TemplateFunction } from "./compile.ts";
 
 export type CallbackFn = (err: Error | null, str?: string) => void;
 

--- a/deno_dist/file-helpers.ts
+++ b/deno_dist/file-helpers.ts
@@ -2,7 +2,7 @@ import { includeFile } from "./file-handlers.ts";
 
 /* TYPES */
 
-import { EtaConfig } from "./config.ts";
+import type { EtaConfig } from "./config.ts";
 
 interface GenericData {
   [index: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/deno_dist/file-utils.ts
+++ b/deno_dist/file-utils.ts
@@ -7,7 +7,7 @@ import EtaErr from "./err.ts";
 
 /* TYPES */
 
-import { EtaConfig } from "./config.ts";
+import type { EtaConfig } from "./config.ts";
 
 /* END TYPES */
 

--- a/deno_dist/parse.ts
+++ b/deno_dist/parse.ts
@@ -3,7 +3,7 @@ import { trimWS } from "./utils.ts";
 
 /* TYPES */
 
-import { EtaConfig } from "./config.ts";
+import type { EtaConfig } from "./config.ts";
 
 export type TagType = "r" | "e" | "i" | "";
 

--- a/deno_dist/render.ts
+++ b/deno_dist/render.ts
@@ -5,9 +5,9 @@ import EtaErr from "./err.ts";
 
 /* TYPES */
 
-import { EtaConfig, PartialConfig } from "./config.ts";
-import { TemplateFunction } from "./compile.ts";
-import { CallbackFn } from "./file-handlers.ts";
+import type { EtaConfig, PartialConfig } from "./config.ts";
+import type { TemplateFunction } from "./compile.ts";
+import type { CallbackFn } from "./file-handlers.ts";
 
 /* END TYPES */
 

--- a/deno_dist/utils.ts
+++ b/deno_dist/utils.ts
@@ -5,7 +5,7 @@ import { trimLeft, trimRight } from "./polyfills.ts";
 
 /* TYPES */
 
-import { EtaConfig } from "./config.ts";
+import type { EtaConfig } from "./config.ts";
 
 interface EscapeMap {
   "&": "&amp;";

--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -2,8 +2,8 @@ import Parse from './parse'
 
 /* TYPES */
 
-import { EtaConfig } from './config'
-import { AstObject } from './parse'
+import type { EtaConfig } from './config'
+import type { AstObject } from './parse'
 
 /* END TYPES */
 

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -4,8 +4,8 @@ import EtaErr from './err'
 
 /* TYPES */
 
-import { EtaConfig, PartialConfig } from './config'
-import { CallbackFn } from './file-handlers'
+import type { EtaConfig, PartialConfig } from './config'
+import type { CallbackFn } from './file-handlers'
 import { getAsyncFunctionConstructor } from './polyfills'
 export type TemplateFunction = (data: object, config: EtaConfig, cb?: CallbackFn) => string
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,8 +4,8 @@ import EtaErr from './err'
 
 /* TYPES */
 
-import { TemplateFunction } from './compile'
-import { Cacher } from './storage'
+import type { TemplateFunction } from './compile'
+import type { Cacher } from './storage'
 
 type trimConfig = 'nl' | 'slurp' | false
 

--- a/src/containers.ts
+++ b/src/containers.ts
@@ -2,7 +2,7 @@ import { Cacher } from './storage'
 
 /* TYPES */
 
-import { TemplateFunction } from './compile'
+import type { TemplateFunction } from './compile'
 
 /* END TYPES */
 

--- a/src/file-handlers.ts
+++ b/src/file-handlers.ts
@@ -9,8 +9,8 @@ import { promiseImpl } from './polyfills'
 
 /* TYPES */
 
-import { EtaConfig, PartialConfig, EtaConfigWithFilename } from './config'
-import { TemplateFunction } from './compile'
+import type { EtaConfig, PartialConfig, EtaConfigWithFilename } from './config'
+import type { TemplateFunction } from './compile'
 
 export type CallbackFn = (err: Error | null, str?: string) => void
 

--- a/src/file-helpers.ts
+++ b/src/file-helpers.ts
@@ -2,7 +2,7 @@ import { includeFile } from './file-handlers'
 
 /* TYPES */
 
-import { EtaConfig } from './config'
+import type { EtaConfig } from './config'
 
 interface GenericData {
   [index: string]: any // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -7,7 +7,7 @@ import EtaErr from './err'
 
 /* TYPES */
 
-import { EtaConfig } from './config'
+import type { EtaConfig } from './config'
 
 /* END TYPES */
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -3,7 +3,7 @@ import { trimWS } from './utils'
 
 /* TYPES */
 
-import { EtaConfig } from './config'
+import type { EtaConfig } from './config'
 
 export type TagType = 'r' | 'e' | 'i' | ''
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -5,9 +5,9 @@ import EtaErr from './err'
 
 /* TYPES */
 
-import { EtaConfig, PartialConfig } from './config'
-import { TemplateFunction } from './compile'
-import { CallbackFn } from './file-handlers'
+import type { EtaConfig, PartialConfig } from './config'
+import type { TemplateFunction } from './compile'
+import type { CallbackFn } from './file-handlers'
 
 /* END TYPES */
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import { trimLeft, trimRight } from './polyfills'
 
 /* TYPES */
 
-import { EtaConfig } from './config'
+import type { EtaConfig } from './config'
 
 interface EscapeMap {
   '&': '&amp;'


### PR DESCRIPTION
Fixes #19

Please note that this removes backcompat with TypeScript versions prior to 3.8 (REF: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html), please flag if that is an issue!