### PR TITLE
Filepath caching!

### DIFF
--- a/deno_dist/compile-string.ts
+++ b/deno_dist/compile-string.ts
@@ -18,7 +18,10 @@ import type { AstObject } from "./parse.ts";
  * ```
  */
 
-export default function compileToString(str: string, config: EtaConfig) {
+export default function compileToString(
+  str: string,
+  config: EtaConfig,
+): string {
   var buffer: Array<AstObject> = Parse(str, config);
 
   var res = "var tR=''" +

--- a/deno_dist/config.ts
+++ b/deno_dist/config.ts
@@ -10,50 +10,53 @@ import type { Cacher } from "./storage.ts";
 type trimConfig = "nl" | "slurp" | false;
 
 export interface EtaConfig {
-  /** Name of the data object. Default `it` */
-  varName: string;
-  /** Configure automatic whitespace trimming. Default `[false, 'nl']` */
-  autoTrim: trimConfig | [trimConfig, trimConfig];
-  /** Remove all safe-to-remove whitespace */
-  rmWhitespace: boolean;
   /** Whether or not to automatically XML-escape interpolations. Default true */
   autoEscape: boolean;
-  /** Delimiters: by default `['<%', '%>']` */
-  tags: [string, string];
+  /** Configure automatic whitespace trimming. Default `[false, 'nl']` */
+  autoTrim: trimConfig | [trimConfig, trimConfig];
+  /** Compile to async function */
+  async: boolean;
+  /** Whether or not to cache templates if `name` or `filename` is passed */
+  cache: boolean;
+  /** XML-escaping function */
+  e: (str: string) => string;
   /** Parsing options */
   parse: {
+    /** Which prefix to use for evaluation. Default `""` */
+    exec: string;
     /** Which prefix to use for interpolation. Default `"="` */
     interpolate: string;
     /** Which prefix to use for raw interpolation. Default `"~"` */
     raw: string;
-    /** Which prefix to use for evaluation. Default `""` */
-    exec: string;
   };
-  /** XML-escaping function */
-  e: (str: string) => string;
+  /** Array of plugins */
   plugins: Array<{ processFnString?: Function; processAST?: Function }>;
-  /** Compile to async function */
-  async: boolean;
+  /** Remove all safe-to-remove whitespace */
+  rmWhitespace: boolean;
+  /** Delimiters: by default `['<%', '%>']` */
+  tags: [string, string];
   /** Holds template cache */
   templates: Cacher<TemplateFunction>;
-  /** Whether or not to cache templates if `name` or `filename` is passed */
-  cache: boolean;
-  /** Directories that contain templates */
-  views?: string | Array<string>;
-  /** Where should absolute paths begin? Default '/' */
-  root?: string;
+  /** Name of the data object. Default `it` */
+  varName: string;
   /** Absolute path to template file */
   filename?: string;
-  /** Name of template file */
-  name?: string;
-  /** Whether or not to cache templates if `name` or `filename` is passed */
-  "view cache"?: boolean;
-  /** Make data available on the global object instead of varName */
-  useWith?: boolean;
+  /** Holds cache of resolved filepaths. Set to `false` to disable */
+  filepathCache?: object | false;
   /** Function to include templates by name */
   include?: Function;
   /** Function to include templates by filepath */
   includeFile?: Function;
+  /** Name of template */
+  name?: string;
+  /** Where should absolute paths begin? Default '/' */
+  root?: string;
+  /** Make data available on the global object instead of varName */
+  useWith?: boolean;
+  /** Whether or not to cache templates if `name` or `filename` is passed: duplicate of `cache` */
+  "view cache"?: boolean;
+  /** Directories that contain templates */
+  views?: string | Array<string>;
   [index: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
@@ -85,23 +88,23 @@ function includeHelper(
 
 /** Eta's base (global) configuration */
 var config: EtaConfig = {
-  varName: "it",
-  autoTrim: [false, "nl"],
-  rmWhitespace: false,
-  autoEscape: true,
-  tags: ["<%", "%>"],
-  parse: {
-    interpolate: "=",
-    raw: "~",
-    exec: "",
-  },
   async: false,
-  templates: templates,
+  autoEscape: true,
+  autoTrim: [false, "nl"],
   cache: false,
-  plugins: [],
-  useWith: false,
   e: XMLEscape,
   include: includeHelper,
+  parse: {
+    exec: "",
+    interpolate: "=",
+    raw: "~",
+  },
+  plugins: [],
+  rmWhitespace: false,
+  tags: ["<%", "%>"],
+  templates: templates,
+  useWith: false,
+  varName: "it",
 };
 
 /**

--- a/deno_dist/config.ts
+++ b/deno_dist/config.ts
@@ -12,51 +12,73 @@ type trimConfig = "nl" | "slurp" | false;
 export interface EtaConfig {
   /** Whether or not to automatically XML-escape interpolations. Default true */
   autoEscape: boolean;
+
   /** Configure automatic whitespace trimming. Default `[false, 'nl']` */
   autoTrim: trimConfig | [trimConfig, trimConfig];
+
   /** Compile to async function */
   async: boolean;
+
   /** Whether or not to cache templates if `name` or `filename` is passed */
   cache: boolean;
+
   /** XML-escaping function */
   e: (str: string) => string;
+
   /** Parsing options */
   parse: {
     /** Which prefix to use for evaluation. Default `""` */
     exec: string;
+
     /** Which prefix to use for interpolation. Default `"="` */
     interpolate: string;
+
     /** Which prefix to use for raw interpolation. Default `"~"` */
     raw: string;
   };
+
   /** Array of plugins */
   plugins: Array<{ processFnString?: Function; processAST?: Function }>;
+
   /** Remove all safe-to-remove whitespace */
   rmWhitespace: boolean;
+
   /** Delimiters: by default `['<%', '%>']` */
   tags: [string, string];
+
   /** Holds template cache */
   templates: Cacher<TemplateFunction>;
+
   /** Name of the data object. Default `it` */
   varName: string;
+
   /** Absolute path to template file */
   filename?: string;
+
   /** Holds cache of resolved filepaths. Set to `false` to disable */
-  filepathCache?: object | false;
+  filepathCache?: Record<string, string> | false;
+
   /** Function to include templates by name */
   include?: Function;
+
   /** Function to include templates by filepath */
   includeFile?: Function;
+
   /** Name of template */
   name?: string;
+
   /** Where should absolute paths begin? Default '/' */
   root?: string;
+
   /** Make data available on the global object instead of varName */
   useWith?: boolean;
+
   /** Whether or not to cache templates if `name` or `filename` is passed: duplicate of `cache` */
   "view cache"?: boolean;
-  /** Directories that contain templates */
+
+  /** Directory or directories that contain templates */
   views?: string | Array<string>;
+
   [index: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 

--- a/deno_dist/file-utils.ts
+++ b/deno_dist/file-utils.ts
@@ -76,6 +76,7 @@ function getPath(path: string, options: EtaConfig) {
   if (
     options.cache && options.filepathCache && options.filepathCache[pathOptions]
   ) {
+    // Use the cached filepath
     return options.filepathCache[pathOptions];
   }
 

--- a/deno_dist/file-utils.ts
+++ b/deno_dist/file-utils.ts
@@ -62,6 +62,23 @@ function getPath(path: string, options: EtaConfig) {
   var views = options.views;
   var searchedPaths: Array<string> = [];
 
+  // If these four values are the same,
+  // getPath() will return the same result every time.
+  // We can cache the result to avoid expensive
+  // file operations.
+  var pathOptions = JSON.stringify({
+    filename: options.filename,
+    path: path,
+    root: options.root,
+    views: options.views,
+  });
+
+  if (
+    options.cache && options.filepathCache && options.filepathCache[pathOptions]
+  ) {
+    return options.filepathCache[pathOptions];
+  }
+
   /** Add a filepath to the list of paths we've checked for a template */
   function addPathToSearched(pathSearched: string) {
     if (!searchedPaths.includes(pathSearched)) {
@@ -160,6 +177,13 @@ function getPath(path: string, options: EtaConfig) {
       );
     }
   }
+
+  // If caching and filepathCache are enabled,
+  // cache the input & output of this function.
+  if (options.cache && options.filepathCache) {
+    options.filepathCache[pathOptions] = includePath;
+  }
+
   return includePath;
 }
 

--- a/deno_dist/file-utils.ts
+++ b/deno_dist/file-utils.ts
@@ -67,7 +67,7 @@ function getPath(path: string, options: EtaConfig) {
   // We can cache the result to avoid expensive
   // file operations.
   var pathOptions = JSON.stringify({
-    filename: options.filename,
+    filename: options.filename, // filename of the template which called includeFile()
     path: path,
     root: options.root,
     views: options.views,

--- a/deno_dist/mod.ts
+++ b/deno_dist/mod.ts
@@ -3,6 +3,7 @@ import { includeFileHelper } from "./file-helpers.ts";
 import { config } from "./config.ts";
 
 config.includeFile = includeFileHelper;
+config.filepathCache = {};
 
 export {
   loadFile,

--- a/deno_dist/storage.ts
+++ b/deno_dist/storage.ts
@@ -11,7 +11,7 @@ class Cacher<T> {
   define(key: string, val: T) {
     this.cache[key] = val;
   }
-  get(key: string) {
+  get(key: string): T {
     // string | array.
     // TODO: allow array of keys to look down
     // TODO: create plugin to allow referencing helpers, filters with dot notation

--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -18,7 +18,7 @@ import type { AstObject } from './parse'
  * ```
  */
 
-export default function compileToString(str: string, config: EtaConfig) {
+export default function compileToString(str: string, config: EtaConfig): string {
   var buffer: Array<AstObject> = Parse(str, config)
 
   var res =

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,50 +10,53 @@ import type { Cacher } from './storage'
 type trimConfig = 'nl' | 'slurp' | false
 
 export interface EtaConfig {
-  /** Name of the data object. Default `it` */
-  varName: string
-  /** Configure automatic whitespace trimming. Default `[false, 'nl']` */
-  autoTrim: trimConfig | [trimConfig, trimConfig]
-  /** Remove all safe-to-remove whitespace */
-  rmWhitespace: boolean
   /** Whether or not to automatically XML-escape interpolations. Default true */
   autoEscape: boolean
-  /** Delimiters: by default `['<%', '%>']` */
-  tags: [string, string]
+  /** Configure automatic whitespace trimming. Default `[false, 'nl']` */
+  autoTrim: trimConfig | [trimConfig, trimConfig]
+  /** Compile to async function */
+  async: boolean
+  /** Whether or not to cache templates if `name` or `filename` is passed */
+  cache: boolean
+  /** XML-escaping function */
+  e: (str: string) => string
   /** Parsing options */
   parse: {
+    /** Which prefix to use for evaluation. Default `""` */
+    exec: string
     /** Which prefix to use for interpolation. Default `"="` */
     interpolate: string
     /** Which prefix to use for raw interpolation. Default `"~"` */
     raw: string
-    /** Which prefix to use for evaluation. Default `""` */
-    exec: string
   }
-  /** XML-escaping function */
-  e: (str: string) => string
+  /** Array of plugins */
   plugins: Array<{ processFnString?: Function; processAST?: Function }>
-  /** Compile to async function */
-  async: boolean
+  /** Remove all safe-to-remove whitespace */
+  rmWhitespace: boolean
+  /** Delimiters: by default `['<%', '%>']` */
+  tags: [string, string]
   /** Holds template cache */
   templates: Cacher<TemplateFunction>
-  /** Whether or not to cache templates if `name` or `filename` is passed */
-  cache: boolean
-  /** Directories that contain templates */
-  views?: string | Array<string>
-  /** Where should absolute paths begin? Default '/' */
-  root?: string
+  /** Name of the data object. Default `it` */
+  varName: string
   /** Absolute path to template file */
   filename?: string
-  /** Name of template file */
-  name?: string
-  /** Whether or not to cache templates if `name` or `filename` is passed */
-  'view cache'?: boolean
-  /** Make data available on the global object instead of varName */
-  useWith?: boolean
+  /** Holds cache of resolved filepaths. Set to `false` to disable */
+  filepathCache?: object | false
   /** Function to include templates by name */
   include?: Function
   /** Function to include templates by filepath */
   includeFile?: Function
+  /** Name of template */
+  name?: string
+  /** Where should absolute paths begin? Default '/' */
+  root?: string
+  /** Make data available on the global object instead of varName */
+  useWith?: boolean
+  /** Whether or not to cache templates if `name` or `filename` is passed: duplicate of `cache` */
+  'view cache'?: boolean
+  /** Directories that contain templates */
+  views?: string | Array<string>
   [index: string]: any // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
@@ -81,23 +84,23 @@ function includeHelper(this: EtaConfig, templateNameOrPath: string, data: object
 
 /** Eta's base (global) configuration */
 var config: EtaConfig = {
-  varName: 'it',
-  autoTrim: [false, 'nl'],
-  rmWhitespace: false,
-  autoEscape: true,
-  tags: ['<%', '%>'],
-  parse: {
-    interpolate: '=',
-    raw: '~',
-    exec: ''
-  },
   async: false,
-  templates: templates,
+  autoEscape: true,
+  autoTrim: [false, 'nl'],
   cache: false,
-  plugins: [],
-  useWith: false,
   e: XMLEscape,
-  include: includeHelper
+  include: includeHelper,
+  parse: {
+    exec: '',
+    interpolate: '=',
+    raw: '~'
+  },
+  plugins: [],
+  rmWhitespace: false,
+  tags: ['<%', '%>'],
+  templates: templates,
+  useWith: false,
+  varName: 'it'
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,51 +12,73 @@ type trimConfig = 'nl' | 'slurp' | false
 export interface EtaConfig {
   /** Whether or not to automatically XML-escape interpolations. Default true */
   autoEscape: boolean
+
   /** Configure automatic whitespace trimming. Default `[false, 'nl']` */
   autoTrim: trimConfig | [trimConfig, trimConfig]
+
   /** Compile to async function */
   async: boolean
+
   /** Whether or not to cache templates if `name` or `filename` is passed */
   cache: boolean
+
   /** XML-escaping function */
   e: (str: string) => string
+
   /** Parsing options */
   parse: {
     /** Which prefix to use for evaluation. Default `""` */
     exec: string
+
     /** Which prefix to use for interpolation. Default `"="` */
     interpolate: string
+
     /** Which prefix to use for raw interpolation. Default `"~"` */
     raw: string
   }
+
   /** Array of plugins */
   plugins: Array<{ processFnString?: Function; processAST?: Function }>
+
   /** Remove all safe-to-remove whitespace */
   rmWhitespace: boolean
+
   /** Delimiters: by default `['<%', '%>']` */
   tags: [string, string]
+
   /** Holds template cache */
   templates: Cacher<TemplateFunction>
+
   /** Name of the data object. Default `it` */
   varName: string
+
   /** Absolute path to template file */
   filename?: string
+
   /** Holds cache of resolved filepaths. Set to `false` to disable */
   filepathCache?: object | false
+
   /** Function to include templates by name */
   include?: Function
+
   /** Function to include templates by filepath */
   includeFile?: Function
+
   /** Name of template */
   name?: string
+
   /** Where should absolute paths begin? Default '/' */
   root?: string
+
   /** Make data available on the global object instead of varName */
   useWith?: boolean
+
   /** Whether or not to cache templates if `name` or `filename` is passed: duplicate of `cache` */
   'view cache'?: boolean
-  /** Directories that contain templates */
+
+  /** Directory or directories that contain templates */
   views?: string | Array<string>
+
   [index: string]: any // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,7 +56,7 @@ export interface EtaConfig {
   filename?: string
 
   /** Holds cache of resolved filepaths. Set to `false` to disable */
-  filepathCache?: object | false
+  filepathCache?: Record<string, string> | false
 
   /** Function to include templates by name */
   include?: Function

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -63,7 +63,7 @@ function getPath(path: string, options: EtaConfig) {
   // We can cache the result to avoid expensive
   // file operations.
   var pathOptions = JSON.stringify({
-    filename: options.filename,
+    filename: options.filename, // filename of the template which called includeFile()
     path: path,
     root: options.root,
     views: options.views

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -70,6 +70,7 @@ function getPath(path: string, options: EtaConfig) {
   })
 
   if (options.cache && options.filepathCache && options.filepathCache[pathOptions]) {
+    // Use the cached filepath
     return options.filepathCache[pathOptions]
   }
 

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -58,6 +58,21 @@ function getPath(path: string, options: EtaConfig) {
   var views = options.views
   var searchedPaths: Array<string> = []
 
+  // If these four values are the same,
+  // getPath() will return the same result every time.
+  // We can cache the result to avoid expensive
+  // file operations.
+  var pathOptions = JSON.stringify({
+    filename: options.filename,
+    path: path,
+    root: options.root,
+    views: options.views
+  })
+
+  if (options.cache && options.filepathCache && options.filepathCache[pathOptions]) {
+    return options.filepathCache[pathOptions]
+  }
+
   /** Add a filepath to the list of paths we've checked for a template */
   function addPathToSearched(pathSearched: string) {
     if (!searchedPaths.includes(pathSearched)) {
@@ -146,6 +161,13 @@ function getPath(path: string, options: EtaConfig) {
       throw EtaErr('Could not find the template "' + path + '". Paths tried: ' + searchedPaths)
     }
   }
+
+  // If caching and filepathCache are enabled,
+  // cache the input & output of this function.
+  if (options.cache && options.filepathCache) {
+    options.filepathCache[pathOptions] = includePath
+  }
+
   return includePath
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { includeFileHelper } from './file-helpers'
 import { config } from './config'
 
 config.includeFile = includeFileHelper
+config.filepathCache = {}
 
 export { loadFile, renderFile, renderFile as __express } from './file-handlers'
 

--- a/src/mod.deno.ts
+++ b/src/mod.deno.ts
@@ -3,6 +3,7 @@ import { includeFileHelper } from './file-helpers.ts'
 import { config } from './config.ts'
 
 config.includeFile = includeFileHelper
+config.filepathCache = {}
 
 export { loadFile, renderFile, renderFile as __express } from './file-handlers.ts'
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -11,7 +11,7 @@ class Cacher<T> {
   define(key: string, val: T) {
     this.cache[key] = val
   }
-  get(key: string) {
+  get(key: string): T {
     // string | array.
     // TODO: allow array of keys to look down
     // TODO: create plugin to allow referencing helpers, filters with dot notation

--- a/test/file-utils.spec.ts
+++ b/test/file-utils.spec.ts
@@ -1,6 +1,6 @@
 /* global it, expect, describe */
 
-import { loadFile, templates } from '../src/index'
+import { renderFile, loadFile, templates } from '../src/index'
 import { config } from '../src/config'
 
 var path = require('path'),
@@ -11,5 +11,41 @@ describe('File tests', () => {
     loadFile(filePath, { filename: filePath })
     expect(templates.get(filePath)).toBeTruthy()
     expect(templates.get(filePath)({ name: 'Ben' }, config)).toBeTruthy()
+  })
+})
+
+describe('Filepath caching', () => {
+  it('Filepath caching works as expected', async () => {
+    // This test renders templates/has-include.eta with caching enabled, then checks to make sure
+    // `config.filepathCache` contains the expected result afterward
+
+    let viewsDir = path.join(__dirname, 'templates')
+
+    let templateResult = await renderFile('has-include', {}, { views: viewsDir, cache: true })
+
+    expect(templateResult).toEqual(
+      `This is the outermost template. Now we'll include a partial
+
+===========================================================
+This is a partial.
+Hi Test Runner`
+    )
+
+    // The cache is indexed by {filename, path, root, views} (JSON.stringify ignores keys with undefined as their value)
+
+    // Filepath caching is based on the premise that given the same path, includer filename, root directory, and views directory (or directories)
+    // the getPath function will always return the same result (assuming that caching is enabled and we're not expecting the templates to change)
+
+    let pathToHasInclude = `{"filename":"${viewsDir}/has-include.eta","path":"./partial","views":"${viewsDir}"}`
+
+    let pathToPartial = `{"filename":"${viewsDir}/partial.eta","path":"./simple","views":"${viewsDir}"}`
+
+    let pathToSimple = `{"path":"has-include","views":"${viewsDir}"}`
+
+    expect(config.filepathCache).toEqual({
+      [pathToHasInclude]: `${viewsDir}/partial.eta`,
+      [pathToPartial]: `${viewsDir}/simple.eta`,
+      [pathToSimple]: `${viewsDir}/has-include.eta`
+    })
   })
 })

--- a/test/templates/has-include.eta
+++ b/test/templates/has-include.eta
@@ -1,0 +1,4 @@
+This is the outermost template. Now we'll include a partial
+
+===========================================================
+<%~ includeFile('./partial') %>

--- a/test/templates/partial.eta
+++ b/test/templates/partial.eta
@@ -1,0 +1,2 @@
+This is a partial.
+<%~ includeFile('./simple', {name: 'Test Runner'}) %>


### PR DESCRIPTION
Eta uses a function called `getPath(path, options)` to resolve filepaths. Every time the `includeFile` or `renderFile` functions are called, Eta will search within the `views` directory or relative to the current filepath until it finds an existing file. This code was taken almost directly from EJS.

However, this PR takes advantage of the fact that `getPath` relies on only input: `path`, `options.views`, `options.root`, and `options.filepath`. If those remain constant (and the template directory doesn't change), `getPath` should always return the same result.

To use this to our advantage, we can create a new cache for resolved filepaths and their inputs. We'll index it like this:

```js
let pathInput = JSON.stringify({
    filename: options.filename,
    path: path,
    root: options.root,
    views: options.views
})

if (options.cache && pathCache && pathCache[pathInput]) {
	return pathCache[pathInput]
} else {
...
```

Preliminary results show this having a GIANT performance benefit when caching is enabled!

(Using `autocannon -c 100`)

| Server  | Cache disabled                                              | Cache enabled: before PR                                    | Cache enabled: after PR                                     |
|---------|-------------------------------------------------------------|-------------------------------------------------------------|-------------------------------------------------------------|
| Oak     | 20k requests in 10.07s<br>13 MB read<br>49ms avg. latency   | 48k requests in 10.07s<br>30.9 MB read<br>20ms avg. latency | 159k requests in 10.11s<br>101 MB read<br>6ms avg. latency  |
| Alosaur | 23k requests in 10.06s<br>6.28 MB read<br>42ms avg. latency | 61k requests in 10.07s<br>16.6 MB read<br>16ms avg. latency | 210k requests in 10.08s<br>56.6 MB read<br>5ms avg. latency |
| Opine   | 12k requests in 11.06s<br>9.36 MB read<br>88ms avg. latency | 28k requests in 10.07s<br>21 MB read<br>35ms avg. latency   | 54k requests in 10.08s<br>40.9 MB read<br>18ms avg. latency |

_Note that these servers weren't running the same templates, so don't use these results to compare the servers_

The new version of Eta performs drastically better with the new PR! Alosaur, for example, served 3.3 times more data! :fire: :fire: :fire: