### PR TITLE
Layout support

### DIFF
--- a/browser-tests/benchmark.html
+++ b/browser-tests/benchmark.html
@@ -100,8 +100,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
       <script src="https://unpkg.com/dot@1.1.3/doT.min.js"></script>
       <script src="https://unpkg.com/ejs@3.0.1/ejs.min.js"></script>
       <script src="https://unpkg.com/handlebars@4.7.3/dist/handlebars.min.js"></script>
+      <!-- This is a fallback, since ../dist/browser/eta.min.js is not uploaded to GitHub -->
+      <script src="https://unpkg.com/eta"></script>
       <script src="../dist/browser/eta.min.js"></script>
-      <script src="https://unpkg.com/squirrelly@8.0.0-beta.9"></script>
+      <script src="https://unpkg.com/squirrelly@8.0.8"></script>
       <script src="https://unpkg.com/mustache@4.0.0/mustache.min.js"></script>
       <script src="https://pugjs.org/js/pug.js"></script>
       <script src="https://unpkg.com/swig@1.4.2/dist/swig.min.js"></script>

--- a/browser-tests/benchmark.js
+++ b/browser-tests/benchmark.js
@@ -16,7 +16,10 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-Eta.defaultConfig.autoTrim = false
+Eta.configure({
+  autoTrim: false
+})
+
 Sqrl.defaultConfig.autoTrim = false
 
 var templateList = {}
@@ -51,7 +54,7 @@ templateList['template-fast-mode-raw'] = `
 
 templateList['eta'] = `
 <ul>
-    <% for (var i = 0, l = it.list.length; i < l; i ++) { %>
+    <% for (var i = 0, ln = it.list.length; i < ln; i ++) { %>
         <li>User: <%= it.list[i].user %> / Web Site: <%= it.list[i].site %></li>
     <% } %>
 </ul>`
@@ -112,7 +115,7 @@ templateList['handlebars-raw'] = `
 
 templateList['squirrelly'] = `
 <ul>
-{{~each(it.list) => val}}
+{{@each(it.list) => val}}
     <li>User: {{val.user}} / Web Site: {{val.site}}</li>
 {{/each}}
 </ul>`
@@ -146,7 +149,7 @@ var config = {
   escape: true
 }
 
-function getParameterByName (name) {
+function getParameterByName(name) {
   var url = window.location.href
   var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)')
   var results = regex.exec(url)
@@ -261,22 +264,6 @@ var testList = [
   },
 
   {
-    name: 'Jade / pug',
-    tester: function () {
-      var id = config.escape ? 'pug' : 'pug-raw'
-      var source = templateList[id]
-      var pug = require('pug')
-      var html = ''
-      for (var i = 0; i < config.calls; i++) {
-        var fn = pug.compile(source)
-
-        html = fn(data)
-      }
-      return html
-    }
-  },
-
-  {
     name: 'Handlebars',
     tester: function () {
       var id = config.escape ? 'handlebars' : 'handlebars-raw'
@@ -290,38 +277,6 @@ var testList = [
       return html
     }
   },
-  // {
-  //   name: 'Squirrelly',
-  //   tester: function() {
-  //     if (!config.escape) {
-  //       Sqrl.defaultConfig.autoEscape = false
-  //     }
-  //     var source = templateList['squirrelly']
-  //     //   console.log(fn.toString())
-  //     var html = ''
-  //     data.$name = 'temp'
-  //     for (var i = 0; i < config.calls; i++) {
-  //       html = Sqrl.render(source, data)
-  //     }
-  //     return html
-  //   }
-  // },
-  // {
-  //   name: 'Squirrelly - Fast',
-  //   tester: function() {
-  //     if (!config.escape) {
-  //       Sqrl.defaultConfig.autoEscape = false
-  //     }
-  //     var source = templateList['squirrelly-fast']
-  //     //   console.log(fn.toString())
-  //     var html = ''
-  //     data.$name = 'temp'
-  //     for (var i = 0; i < config.calls; i++) {
-  //       html = Sqrl.render(source, data)
-  //     }
-  //     return html
-  //   }
-  // },
   {
     name: 'Eta',
     tester: function () {
@@ -334,6 +289,53 @@ var testList = [
       data.$name = 'temp'
       for (var i = 0; i < config.calls; i++) {
         html = Eta.render(source, data)
+      }
+      return html
+    }
+  },
+  {
+    name: 'Squirrelly',
+    tester: function () {
+      if (!config.escape) {
+        Sqrl.defaultConfig.autoEscape = false
+      }
+      var source = templateList['squirrelly']
+      //   console.log(fn.toString())
+      var html = ''
+      data.$name = 'temp'
+      for (var i = 0; i < config.calls; i++) {
+        html = Sqrl.render(source, data)
+      }
+      return html
+    }
+  },
+  {
+    name: 'Squirrelly - Fast',
+    tester: function () {
+      if (!config.escape) {
+        Sqrl.defaultConfig.autoEscape = false
+      }
+      var source = templateList['squirrelly-fast']
+      //   console.log(fn.toString())
+      var html = ''
+      data.$name = 'temp'
+      for (var i = 0; i < config.calls; i++) {
+        html = Sqrl.render(source, data)
+      }
+      return html
+    }
+  },
+  {
+    name: 'Jade / pug',
+    tester: function () {
+      var id = config.escape ? 'pug' : 'pug-raw'
+      var source = templateList[id]
+      var pug = require('pug')
+      var html = ''
+      for (var i = 0; i < config.calls; i++) {
+        var fn = pug.compile(source)
+
+        html = fn(data)
       }
       return html
     }
@@ -461,7 +463,7 @@ var runTest = function (callback) {
     ]
   })
 
-  function tester (target) {
+  function tester(target) {
     var time = new Timer()
     var html = target.tester()
     var endTime = time.stop()
@@ -495,7 +497,7 @@ window['restart'] = function (key, value) {
   config[key] = value
 }
 
-function getLink () {
+function getLink() {
   window.location.search =
     'length=' + config.length + '&calls=' + config.calls + '&escape=' + config.escape
 }
@@ -509,6 +511,8 @@ window['app'] = function (selector) {
 <br><br>
 <em>Note: doT and Eta usually trade off the lead on unescaped templates. Keep in mind that Eta supports template tags inside strings & comments, plugins, whitespace trimming, etc.</em>
 <br><br>
+<em>Note: these benchmarks are ONLY VALID if page is served by a server (localhost, RawGit are ok). Otherwise results are highly variable and inaccurate (I don't know why!)</em>
+<br><br>
 <strong>Longer (more ops/sec) is better</strong>
 
 <div class="header">
@@ -520,7 +524,7 @@ window['app'] = function (selector) {
         <label><input type="number" value="{{it.length}}" onchange="restart('length', this.value)"> list</label>
         <strong>×</strong>
         <label><input type="number" value="{{it.calls}}" onchange="restart('calls', this.value)"> calls</label>
-        <label><input type="checkbox" {{~if(it.escape)}}checked{{/if}} onchange="restart('escape', this.checked)"> escape</label>
+        <label><input type="checkbox" {{@if(it.escape)}}checked{{/if}} onchange="restart('escape', this.checked)"> escape</label>
         <button id="get-link" class="button">&#x1f517; Get link</button>
 
     </p>

--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -8,9 +8,7 @@
 </p>
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
-[logo]: https://img.shields.io/badge/all_contributors-3-orange.svg 'Number of contributors on All-Contributors'
-
+[logo]: https://img.shields.io/badge/all_contributors-4-orange.svg 'Number of contributors on All-Contributors'
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <span align="center">
@@ -207,12 +205,12 @@ Made with ❤ by [@nebrelbug](https://github.com/eta-dev) and all these wonderfu
     <td align="center"><a href="http://www.bengubler.com"><img src="https://avatars3.githubusercontent.com/u/25597854?v=4" width="100px;" alt=""/><br /><sub><b>Ben Gubler</b></sub></a><br /><a href="https://github.com/eta-dev/eta/commits?author=nebrelbug" title="Code">💻</a> <a href="#question-nebrelbug" title="Answering Questions">💬</a> <a href="https://github.com/eta-dev/eta/commits?author=nebrelbug" title="Documentation">📖</a> <a href="https://github.com/eta-dev/eta/commits?author=nebrelbug" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/clitetailor"><img src="https://avatars1.githubusercontent.com/u/16368559?v=4" width="100px;" alt=""/><br /><sub><b>Clite Tailor</b></sub></a><br /><a href="#ideas-clitetailor" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/eta-dev/eta/commits?author=clitetailor" title="Code">💻</a></td>
     <td align="center"><a href="https://twitter.com/ioan_chiriac"><img src="https://avatars2.githubusercontent.com/u/173203?v=4" width="100px;" alt=""/><br /><sub><b>Ioan CHIRIAC</b></sub></a><br /><a href="https://github.com/eta-dev/eta/commits?author=ichiriac" title="Code">💻</a> <a href="#ideas-ichiriac" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://www.linkedin.com/in/craig-morten/"><img src="https://avatars1.githubusercontent.com/u/46491566?v=4" width="100px;" alt=""/><br /><sub><b>Craig Morten</b></sub></a><br /><a href="https://github.com/eta-dev/eta/commits?author=asos-craigmorten" title="Code">💻</a></td>
   </tr>
 </table>
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind are welcome!

--- a/deno_dist/compile-string.ts
+++ b/deno_dist/compile-string.ts
@@ -24,20 +24,20 @@ export default function compileToString(
 ): string {
   var buffer: Array<AstObject> = Parse(str, config);
 
-  var res = "var tR='',l" +
+  var res = "var tR='',__l" +
     (config.include ? ",include=E.include.bind(E)" : "") +
     (config.includeFile ? ",includeFile=E.includeFile.bind(E)" : "") +
-    "\nfunction layout(p){l=p}\n" +
+    "\nfunction layout(p){__l=p}\n" +
     (config.useWith ? "with(" + config.varName + "||{}){" : "") +
     compileScope(buffer, config) +
     (config.includeFile
-      ? "if(l)tR=" +
+      ? "if(__l)tR=" +
         (config.async ? "await " : "") +
-        `includeFile(l,Object.assign(${config.varName},{body:tR}))\n`
+        `includeFile(__l,Object.assign(${config.varName},{body:tR}))\n`
       : config.include
-      ? "if(l)tR=" +
+      ? "if(__l)tR=" +
         (config.async ? "await " : "") +
-        `include(l,Object.assign(${config.varName},{body:tR}))\n`
+        `include(__l,Object.assign(${config.varName},{body:tR}))\n`
       : "") +
     "if(cb){cb(null,tR)} return tR" +
     (config.useWith ? "}" : "");

--- a/deno_dist/compile-string.ts
+++ b/deno_dist/compile-string.ts
@@ -24,12 +24,21 @@ export default function compileToString(
 ): string {
   var buffer: Array<AstObject> = Parse(str, config);
 
-  var res = "var tR=''" +
+  var res = "var tR='',l" +
     (config.include ? ",include=E.include.bind(E)" : "") +
     (config.includeFile ? ",includeFile=E.includeFile.bind(E)" : "") +
-    "\n" +
+    "\nfunction layout(p){l=p}\n" +
     (config.useWith ? "with(" + config.varName + "||{}){" : "") +
     compileScope(buffer, config) +
+    (config.includeFile
+      ? "if(l)tR=" +
+        (config.async ? "await " : "") +
+        `includeFile(l,Object.assign(${config.varName},{body:tR}))\n`
+      : config.include
+      ? "if(l)tR=" +
+        (config.async ? "await " : "") +
+        `include(l,Object.assign(${config.varName},{body:tR}))\n`
+      : "") +
     "if(cb){cb(null,tR)} return tR" +
     (config.useWith ? "}" : "");
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "require": "./dist/eta.cjs.js",
     "browser": "./dist/browser/eta.min.js"
   },
+  "types": "dist/types/index.d.ts",
   "typings": "dist/types/index.d.ts",
   "jsdelivr": "dist/browser/eta.min.js",
   "unpkg": "dist/browser/eta.min.js",

--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -22,12 +22,21 @@ export default function compileToString(str: string, config: EtaConfig): string 
   var buffer: Array<AstObject> = Parse(str, config)
 
   var res =
-    "var tR=''" +
+    "var tR='',l" +
     (config.include ? ',include=E.include.bind(E)' : '') +
     (config.includeFile ? ',includeFile=E.includeFile.bind(E)' : '') +
-    '\n' +
+    '\nfunction layout(p){l=p}\n' +
     (config.useWith ? 'with(' + config.varName + '||{}){' : '') +
     compileScope(buffer, config) +
+    (config.includeFile
+      ? 'if(l)tR=' +
+        (config.async ? 'await ' : '') +
+        `includeFile(l,Object.assign(${config.varName},{body:tR}))\n`
+      : config.include
+      ? 'if(l)tR=' +
+        (config.async ? 'await ' : '') +
+        `include(l,Object.assign(${config.varName},{body:tR}))\n`
+      : '') +
     'if(cb){cb(null,tR)} return tR' +
     (config.useWith ? '}' : '')
 

--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -22,20 +22,20 @@ export default function compileToString(str: string, config: EtaConfig): string 
   var buffer: Array<AstObject> = Parse(str, config)
 
   var res =
-    "var tR='',l" +
+    "var tR='',__l" +
     (config.include ? ',include=E.include.bind(E)' : '') +
     (config.includeFile ? ',includeFile=E.includeFile.bind(E)' : '') +
-    '\nfunction layout(p){l=p}\n' +
+    '\nfunction layout(p){__l=p}\n' +
     (config.useWith ? 'with(' + config.varName + '||{}){' : '') +
     compileScope(buffer, config) +
     (config.includeFile
-      ? 'if(l)tR=' +
+      ? 'if(__l)tR=' +
         (config.async ? 'await ' : '') +
-        `includeFile(l,Object.assign(${config.varName},{body:tR}))\n`
+        `includeFile(__l,Object.assign(${config.varName},{body:tR}))\n`
       : config.include
-      ? 'if(l)tR=' +
+      ? 'if(__l)tR=' +
         (config.async ? 'await ' : '') +
-        `include(l,Object.assign(${config.varName},{body:tR}))\n`
+        `include(__l,Object.assign(${config.varName},{body:tR}))\n`
       : '') +
     'if(cb){cb(null,tR)} return tR' +
     (config.useWith ? '}' : '')

--- a/test/async.spec.ts
+++ b/test/async.spec.ts
@@ -47,8 +47,10 @@ describe('Async Render checks', () => {
         await Eta.render('<%= @#$%^ %>', {}, { async: true })
       }).rejects.toThrow(
         buildRegEx(`
-var tR='',include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){l=p}
 tR+=E.e(@#$%^)
+if(l)tR=await includeFile(l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR
 `)
       )
@@ -59,8 +61,10 @@ if(cb){cb(null,tR)} return tR
         expect(err).toBeTruthy()
         expect((err as Error).message).toMatch(
           buildRegEx(`
-var tR='',include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){l=p}
 tR+=E.e(@#$%^)
+if(l)tR=await includeFile(l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR
 `)
         )

--- a/test/async.spec.ts
+++ b/test/async.spec.ts
@@ -47,10 +47,10 @@ describe('Async Render checks', () => {
         await Eta.render('<%= @#$%^ %>', {}, { async: true })
       }).rejects.toThrow(
         buildRegEx(`
-var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
-function layout(p){l=p}
+var tR='',__l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){__l=p}
 tR+=E.e(@#$%^)
-if(l)tR=await includeFile(l,Object.assign(it,{body:tR}))
+if(__l)tR=await includeFile(__l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR
 `)
       )
@@ -61,10 +61,10 @@ if(cb){cb(null,tR)} return tR
         expect(err).toBeTruthy()
         expect((err as Error).message).toMatch(
           buildRegEx(`
-var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
-function layout(p){l=p}
+var tR='',__l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){__l=p}
 tR+=E.e(@#$%^)
-if(l)tR=await includeFile(l,Object.assign(it,{body:tR}))
+if(__l)tR=await includeFile(__l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR
 `)
         )

--- a/test/compile-string.spec.ts
+++ b/test/compile-string.spec.ts
@@ -10,8 +10,7 @@ const complexTemplate = fs.readFileSync(filePath, 'utf8')
 describe('Compile to String test', () => {
   it('parses a simple template', () => {
     var str = compileToString('hi <%= hey %>', defaultConfig)
-    expect(str)
-      .toEqual(`var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+    expect(str).toEqual(`var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
 function layout(p){l=p}
 tR+='hi '
 tR+=E.e(hey)
@@ -33,8 +32,7 @@ if(cb){cb(null,tR)} return tR`)
 
   it('parses a simple template with raw tag', () => {
     var str = compileToString('hi <%~ hey %>', defaultConfig)
-    expect(str)
-      .toEqual(`var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+    expect(str).toEqual(`var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
 function layout(p){l=p}
 tR+='hi '
 tR+=hey
@@ -44,8 +42,7 @@ if(cb){cb(null,tR)} return tR`)
 
   it('works with whitespace trimming', () => {
     var str = compileToString('hi\n<%- = hey-%>\n<%_ = hi_%>', defaultConfig)
-    expect(str)
-      .toEqual(`var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+    expect(str).toEqual(`var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
 function layout(p){l=p}
 tR+='hi'
 tR+=E.e(hey)

--- a/test/compile-string.spec.ts
+++ b/test/compile-string.spec.ts
@@ -10,11 +10,11 @@ const complexTemplate = fs.readFileSync(filePath, 'utf8')
 describe('Compile to String test', () => {
   it('parses a simple template', () => {
     var str = compileToString('hi <%= hey %>', defaultConfig)
-    expect(str).toEqual(`var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
-function layout(p){l=p}
+    expect(str).toEqual(`var tR='',__l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){__l=p}
 tR+='hi '
 tR+=E.e(hey)
-if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
+if(__l)tR=includeFile(__l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR`)
   })
 
@@ -23,8 +23,8 @@ if(cb){cb(null,tR)} return tR`)
       'hi <%= hey %>',
       getConfig({ include: undefined, includeFile: undefined })
     )
-    expect(str).toEqual(`var tR='',l
-function layout(p){l=p}
+    expect(str).toEqual(`var tR='',__l
+function layout(p){__l=p}
 tR+='hi '
 tR+=E.e(hey)
 if(cb){cb(null,tR)} return tR`)
@@ -32,30 +32,30 @@ if(cb){cb(null,tR)} return tR`)
 
   it('parses a simple template with raw tag', () => {
     var str = compileToString('hi <%~ hey %>', defaultConfig)
-    expect(str).toEqual(`var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
-function layout(p){l=p}
+    expect(str).toEqual(`var tR='',__l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){__l=p}
 tR+='hi '
 tR+=hey
-if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
+if(__l)tR=includeFile(__l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR`)
   })
 
   it('works with whitespace trimming', () => {
     var str = compileToString('hi\n<%- = hey-%>\n<%_ = hi_%>', defaultConfig)
-    expect(str).toEqual(`var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
-function layout(p){l=p}
+    expect(str).toEqual(`var tR='',__l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){__l=p}
 tR+='hi'
 tR+=E.e(hey)
 tR+=E.e(hi)
-if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
+if(__l)tR=includeFile(__l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR`)
   })
 
   it('compiles complex template', () => {
     var str = compileToString(complexTemplate, defaultConfig)
     expect(str).toEqual(
-      `var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
-function layout(p){l=p}
+      `var tR='',__l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){__l=p}
 tR+='Hi\\n'
 console.log("Hope you like Eta!")
 tR+=E.e(it.htmlstuff)
@@ -79,7 +79,7 @@ tR+='      \\n  '
 }
 tR+='\\nThis is a partial: '
 tR+=include("mypartial")
-if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
+if(__l)tR=includeFile(__l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR`
     )
   })

--- a/test/compile-string.spec.ts
+++ b/test/compile-string.spec.ts
@@ -10,9 +10,12 @@ const complexTemplate = fs.readFileSync(filePath, 'utf8')
 describe('Compile to String test', () => {
   it('parses a simple template', () => {
     var str = compileToString('hi <%= hey %>', defaultConfig)
-    expect(str).toEqual(`var tR='',include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+    expect(str)
+      .toEqual(`var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){l=p}
 tR+='hi '
 tR+=E.e(hey)
+if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR`)
   })
 
@@ -21,7 +24,8 @@ if(cb){cb(null,tR)} return tR`)
       'hi <%= hey %>',
       getConfig({ include: undefined, includeFile: undefined })
     )
-    expect(str).toEqual(`var tR=''
+    expect(str).toEqual(`var tR='',l
+function layout(p){l=p}
 tR+='hi '
 tR+=E.e(hey)
 if(cb){cb(null,tR)} return tR`)
@@ -29,25 +33,32 @@ if(cb){cb(null,tR)} return tR`)
 
   it('parses a simple template with raw tag', () => {
     var str = compileToString('hi <%~ hey %>', defaultConfig)
-    expect(str).toEqual(`var tR='',include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+    expect(str)
+      .toEqual(`var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){l=p}
 tR+='hi '
 tR+=hey
+if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR`)
   })
 
   it('works with whitespace trimming', () => {
     var str = compileToString('hi\n<%- = hey-%>\n<%_ = hi_%>', defaultConfig)
-    expect(str).toEqual(`var tR='',include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+    expect(str)
+      .toEqual(`var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){l=p}
 tR+='hi'
 tR+=E.e(hey)
 tR+=E.e(hi)
+if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR`)
   })
 
   it('compiles complex template', () => {
     var str = compileToString(complexTemplate, defaultConfig)
     expect(str).toEqual(
-      `var tR='',include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+      `var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){l=p}
 tR+='Hi\\n'
 console.log("Hope you like Eta!")
 tR+=E.e(it.htmlstuff)
@@ -71,6 +82,7 @@ tR+='      \\n  '
 }
 tR+='\\nThis is a partial: '
 tR+=include("mypartial")
+if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR`
     )
   })

--- a/test/compile.spec.ts
+++ b/test/compile.spec.ts
@@ -31,10 +31,10 @@ describe('Compile test', () => {
       compile('<% hi (=h) %>')
     }).toThrow(
       buildRegEx(`
-var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
-function layout(p){l=p}
+var tR='',__l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){__l=p}
 hi (=h)
-if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
+if(__l)tR=includeFile(__l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR
 `)
     )

--- a/test/compile.spec.ts
+++ b/test/compile.spec.ts
@@ -31,8 +31,10 @@ describe('Compile test', () => {
       compile('<% hi (=h) %>')
     }).toThrow(
       buildRegEx(`
-var tR='',include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){l=p}
 hi (=h)
+if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR
 `)
     )

--- a/test/file-handlers.spec.ts
+++ b/test/file-handlers.spec.ts
@@ -107,11 +107,11 @@ describe('renderFile error tests', () => {
       expect(err).toBeTruthy()
       expect(err.message).toMatch(
         buildRegEx(`
-var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
-function layout(p){l=p}
+var tR='',__l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){__l=p}
 tR+='Hi '
 tR+=E.e(badSyntax(=!)
-if(l)tR=await includeFile(l,Object.assign(it,{body:tR}))
+if(__l)tR=await includeFile(__l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR
 `)
       )
@@ -126,11 +126,11 @@ if(cb){cb(null,tR)} return tR
       await renderFile(errFilePath, {})
     }).rejects.toThrow(
       buildRegEx(`
-var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
-function layout(p){l=p}
+var tR='',__l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){__l=p}
 tR+='Hi '
 tR+=E.e(badSyntax(=!)
-if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
+if(__l)tR=includeFile(__l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR
 `)
     )
@@ -146,11 +146,11 @@ Bad template syntax
 
 Unexpected token '='
 ====================
-var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
-function layout(p){l=p}
+var tR='',__l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){__l=p}
 tR+='Hi '
 tR+=E.e(badSyntax(=!)
-if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
+if(__l)tR=includeFile(__l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR
 */
 

--- a/test/file-handlers.spec.ts
+++ b/test/file-handlers.spec.ts
@@ -107,9 +107,11 @@ describe('renderFile error tests', () => {
       expect(err).toBeTruthy()
       expect(err.message).toMatch(
         buildRegEx(`
-var tR='',include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){l=p}
 tR+='Hi '
 tR+=E.e(badSyntax(=!)
+if(l)tR=await includeFile(l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR
 `)
       )
@@ -124,9 +126,11 @@ if(cb){cb(null,tR)} return tR
       await renderFile(errFilePath, {})
     }).rejects.toThrow(
       buildRegEx(`
-var tR='',include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){l=p}
 tR+='Hi '
 tR+=E.e(badSyntax(=!)
+if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR
 `)
     )
@@ -142,9 +146,11 @@ Bad template syntax
 
 Unexpected token '='
 ====================
-var tR='',include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+var tR='',l,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
+function layout(p){l=p}
 tR+='Hi '
 tR+=E.e(badSyntax(=!)
+if(l)tR=includeFile(l,Object.assign(it,{body:tR}))
 if(cb){cb(null,tR)} return tR
 */
 

--- a/test/layouts.spec.ts
+++ b/test/layouts.spec.ts
@@ -1,15 +1,15 @@
 import { path } from '../src/file-methods'
 /* global it, expect, describe */
 
-import { renderFile } from '../src/index'
+import { compile, render, renderFile, templates } from '../src/index'
 
 describe('Layout Tests', () => {
-  it('Layout works as expected', async () => {
+  it('Nested layouts work as expected', async () => {
     var res = await renderFile(
       'index.eta',
       { title: 'Cool  Title' },
       // Async can be true or false
-      { views: path.join(__dirname, 'templates'), async: false }
+      { views: path.join(__dirname, 'templates'), async: true }
     )
 
     expect(res).toEqual(`<!DOCTYPE html>
@@ -21,5 +21,21 @@ describe('Layout Tests', () => {
 This is the template body.
 </body>
 </html>`)
+  })
+
+  it('Layouts fall back to include if includeFile is undefined', async () => {
+    templates.define(
+      'my-layout',
+      compile(`###<%= it.title %>###,<%~ it.body %>`, { includeFile: undefined })
+    )
+
+    var res = await render(
+      `<% layout("my-layout") %>
+This is a layout`,
+      { title: 'Cool Title' },
+      { includeFile: undefined }
+    )
+
+    expect(res).toEqual('###Cool Title###,This is a layout')
   })
 })

--- a/test/layouts.spec.ts
+++ b/test/layouts.spec.ts
@@ -1,0 +1,25 @@
+import { path } from '../src/file-methods'
+/* global it, expect, describe */
+
+import { renderFile } from '../src/index'
+
+describe('Layout Tests', () => {
+  it('Layout works as expected', async () => {
+    var res = await renderFile(
+      'index.eta',
+      { title: 'Cool  Title' },
+      // Async can be true or false
+      { views: path.join(__dirname, 'templates'), async: false }
+    )
+
+    expect(res).toEqual(`<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Cool  Title</title>
+</head>
+<body>
+This is the template body.
+</body>
+</html>`)
+  })
+})

--- a/test/templates/index.eta
+++ b/test/templates/index.eta
@@ -1,0 +1,2 @@
+<% layout('./layout') %>
+This is the template body.

--- a/test/templates/layout.eta
+++ b/test/templates/layout.eta
@@ -1,0 +1,7 @@
+<% layout('./outer-layout') %>
+<head>
+    <title><%= it.title %></title>
+</head>
+<body>
+<%~ it.body %>
+</body>

--- a/test/templates/outer-layout.eta
+++ b/test/templates/outer-layout.eta
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html lang="en">
+<%~ it.body %>
+</html>


### PR DESCRIPTION
## TL;DR

This PR adds layout support to Eta! It's used like
```ejs
<% layout("./template") %>
```
The feature only added about 60 bytes to the bundle size and has essentially no runtime cost if unused. Layout functionality is implemented within the template in strictly JavaScript. Layouts can be nested or even changed based on conditionals:
```ejs
<% if (user.type === 'admin') { %>
  <% layout('./admin') %>
<% } else { %>
  <% layout('./user') %>
<% } %>
```

## Rationale

EJS spin-offs, like EJS-Mate and EJS-locals, were created just to add support for layouts to EJS. 

Neither of the above are actively maintained, though, and EJS still doesn't have formal layout support.

My hope is that Eta's support for layouts will drive adoption in the developer community.

## Implementation

A variable called `__l` is created to hold the layout path or name. The `layout` function accepts one parameter (the layout path or name), which it sets `__l` to.

Right before returning, we add a quick check. If `__l` is defined, we call `includeFile` (or, if that is undefined, `include`) with `(__l,Object.assign(it,{body:tR}))`.

The advantages of this approach?
- High flexibility
- No complex parsers, and thus great performance
- No need for pre-render or post-compile hooks