### PR TITLE
Add processTemplate plugin hook

### DIFF
--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img align="center" width="50%" src="https://user-images.githubusercontent.com/25597854/93541153-d8c8fe80-f912-11ea-9e65-a0089ca6d2b6.png">
+</p>
+
 <h1 align="center" style="text-align: center; width: fit-content; margin-left: auto; margin-right: auto;">eta (η)</h1>
 
 <p align="center">

--- a/deno_dist/config.ts
+++ b/deno_dist/config.ts
@@ -38,7 +38,13 @@ export interface EtaConfig {
   };
 
   /** Array of plugins */
-  plugins: Array<{ processFnString?: Function; processAST?: Function }>;
+  plugins: Array<
+    {
+      processFnString?: Function;
+      processAST?: Function;
+      processTemplate?: Function;
+    }
+  >;
 
   /** Remove all safe-to-remove whitespace */
   rmWhitespace: boolean;

--- a/deno_dist/parse.ts
+++ b/deno_dist/parse.ts
@@ -39,6 +39,15 @@ export default function parse(
   var lastIndex = 0;
   var parseOptions = config.parse;
 
+  if (config.plugins) {
+    for (var i = 0; i < config.plugins.length; i++) {
+      var plugin = config.plugins[i];
+      if (plugin.processTemplate) {
+        str = plugin.processTemplate(str, config);
+      }
+    }
+  }
+
   /* Adding for EJS compatibility */
   if (config.rmWhitespace) {
     // Code taken directly from EJS

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,7 @@ export interface EtaConfig {
   }
 
   /** Array of plugins */
-  plugins: Array<{ processFnString?: Function; processAST?: Function }>
+  plugins: Array<{ processFnString?: Function; processAST?: Function; processTemplate?: Function }>
 
   /** Remove all safe-to-remove whitespace */
   rmWhitespace: boolean

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -35,6 +35,15 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
   var lastIndex = 0
   var parseOptions = config.parse
 
+  if (config.plugins) {
+    for (var i = 0; i < config.plugins.length; i++) {
+      var plugin = config.plugins[i]
+      if (plugin.processTemplate) {
+        str = plugin.processTemplate(str, config)
+      }
+    }
+  }
+
   /* Adding for EJS compatibility */
   if (config.rmWhitespace) {
     // Code taken directly from EJS

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -53,3 +53,57 @@ describe('Renders with different scopes', () => {
     )
   })
 })
+
+describe('processTemplate plugin', () => {
+  it('Simple plugin works correctly', () => {
+    let template = ':thumbsup:'
+
+    let emojiTransform = {
+      processTemplate: function (str: string) {
+        return str.replace(':thumbsup:', '👍')
+      }
+    }
+
+    let res = render(
+      template,
+      {},
+      {
+        plugins: [emojiTransform]
+      }
+    )
+
+    expect(res).toEqual('👍')
+  })
+
+  it('Multiple chained plugins work correctly', () => {
+    let template = ':thumbsup: This is a cool template'
+
+    let emojiTransform = {
+      processTemplate: function (str: string) {
+        return str.replace(':thumbsup:', '👍')
+      }
+    }
+
+    let capitalizeCool = {
+      processTemplate: function (str: string) {
+        return str.replace('cool', 'COOL')
+      }
+    }
+
+    let replaceThumbsUp = {
+      processTemplate: function (str: string) {
+        return str.replace('👍', '✨')
+      }
+    }
+
+    let res = render(
+      template,
+      {},
+      {
+        plugins: [emojiTransform, capitalizeCool, replaceThumbsUp]
+      }
+    )
+
+    expect(res).toEqual('✨ This is a COOL template')
+  })
+})


### PR DESCRIPTION
That's right. In just 30 bytes, we added another plugin hook!

This one is called `processTemplate`, and it allows you to modify a template string before it's parsed. It can be used for HTML minification, Gemoji replacement, linting, pre-processing, etc.