### PR TITLE
refactor: use const instead of var where applicable

### DIFF
--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -19,7 +19,7 @@ import type { AstObject } from './parse'
  */
 
 export default function compileToString(str: string, config: EtaConfig): string {
-  var buffer: Array<AstObject> = Parse(str, config)
+  const buffer: Array<AstObject> = Parse(str, config)
 
   var res =
     "var tR='',__l,__lP" +
@@ -42,7 +42,7 @@ export default function compileToString(str: string, config: EtaConfig): string 
 
   if (config.plugins) {
     for (var i = 0; i < config.plugins.length; i++) {
-      var plugin = config.plugins[i]
+      const plugin = config.plugins[i]
       if (plugin.processFnString) {
         res = plugin.processFnString(res, config)
       }
@@ -67,18 +67,18 @@ export default function compileToString(str: string, config: EtaConfig): string 
 
 function compileScope(buff: Array<AstObject>, config: EtaConfig) {
   var i = 0
-  var buffLength = buff.length
+  const buffLength = buff.length
   var returnStr = ''
 
   for (i; i < buffLength; i++) {
-    var currentBlock = buff[i]
+    const currentBlock = buff[i]
     if (typeof currentBlock === 'string') {
-      var str = currentBlock
+      const str = currentBlock
 
       // we know string exists
       returnStr += "tR+='" + str + "'\n"
     } else {
-      var type = currentBlock.t // ~, s, !, ?, r
+      const type = currentBlock.t // ~, s, !, ?, r
       var content = currentBlock.val || ''
 
       if (type === 'r') {

--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -21,7 +21,7 @@ import type { AstObject } from './parse'
 export default function compileToString(str: string, config: EtaConfig): string {
   const buffer: Array<AstObject> = Parse(str, config)
 
-  var res =
+  let res =
     "var tR='',__l,__lP" +
     (config.include ? ',include=E.include.bind(E)' : '') +
     (config.includeFile ? ',includeFile=E.includeFile.bind(E)' : '') +
@@ -41,7 +41,7 @@ export default function compileToString(str: string, config: EtaConfig): string 
     (config.useWith ? '}' : '')
 
   if (config.plugins) {
-    for (var i = 0; i < config.plugins.length; i++) {
+    for (let i = 0; i < config.plugins.length; i++) {
       const plugin = config.plugins[i]
       if (plugin.processFnString) {
         res = plugin.processFnString(res, config)
@@ -66,9 +66,9 @@ export default function compileToString(str: string, config: EtaConfig): string 
  */
 
 function compileScope(buff: Array<AstObject>, config: EtaConfig) {
-  var i = 0
+  let i = 0
   const buffLength = buff.length
-  var returnStr = ''
+  let returnStr = ''
 
   for (i; i < buffLength; i++) {
     const currentBlock = buff[i]
@@ -79,7 +79,7 @@ function compileScope(buff: Array<AstObject>, config: EtaConfig) {
       returnStr += "tR+='" + str + "'\n"
     } else {
       const type = currentBlock.t // ~, s, !, ?, r
-      var content = currentBlock.val || ''
+      let content = currentBlock.val || ''
 
       if (type === 'r') {
         // raw

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -28,7 +28,7 @@ export type TemplateFunction = (data: object, config: EtaConfig, cb?: CallbackFn
  */
 
 export default function compile(str: string, config?: PartialConfig): TemplateFunction {
-  var options: EtaConfig = getConfig(config || {})
+  const options: EtaConfig = getConfig(config || {})
   var ctor // constructor
 
   /* ASYNC HANDLING */

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -29,16 +29,12 @@ export type TemplateFunction = (data: object, config: EtaConfig, cb?: CallbackFn
 
 export default function compile(str: string, config?: PartialConfig): TemplateFunction {
   const options: EtaConfig = getConfig(config || {})
-  let ctor // constructor
 
   /* ASYNC HANDLING */
   // The below code is modified from mde/ejs. All credit should go to them.
-  if (options.async) {
-    ctor = getAsyncFunctionConstructor() as FunctionConstructor
-  } else {
-    ctor = Function
-  }
+  const ctor = options.async ? getAsyncFunctionConstructor() as FunctionConstructor : Function
   /* END ASYNC HANDLING */
+
   try {
     return new ctor(
       options.varName,

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -29,7 +29,7 @@ export type TemplateFunction = (data: object, config: EtaConfig, cb?: CallbackFn
 
 export default function compile(str: string, config?: PartialConfig): TemplateFunction {
   const options: EtaConfig = getConfig(config || {})
-  var ctor // constructor
+  let ctor // constructor
 
   /* ASYNC HANDLING */
   // The below code is modified from mde/ejs. All credit should go to them.

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -32,7 +32,7 @@ export default function compile(str: string, config?: PartialConfig): TemplateFu
 
   /* ASYNC HANDLING */
   // The below code is modified from mde/ejs. All credit should go to them.
-  const ctor = options.async ? getAsyncFunctionConstructor() as FunctionConstructor : Function
+  const ctor = options.async ? (getAsyncFunctionConstructor() as FunctionConstructor) : Function
   /* END ASYNC HANDLING */
 
   try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,7 +100,7 @@ export type PartialConfig = Partial<EtaConfig>
  */
 
 function includeHelper(this: EtaConfig, templateNameOrPath: string, data: object): string {
-  var template = this.templates.get(templateNameOrPath)
+  const template = this.templates.get(templateNameOrPath)
   if (!template) {
     throw EtaErr('Could not fetch template "' + templateNameOrPath + '"')
   }
@@ -108,7 +108,7 @@ function includeHelper(this: EtaConfig, templateNameOrPath: string, data: object
 }
 
 /** Eta's base (global) configuration */
-var config: EtaConfig = {
+const config: EtaConfig = {
   async: false,
   autoEscape: true,
   autoTrim: [false, 'nl'],
@@ -144,7 +144,7 @@ var config: EtaConfig = {
 function getConfig(override: PartialConfig, baseConfig?: EtaConfig): EtaConfig {
   // TODO: run more tests on this
 
-  var res: PartialConfig = {} // Linked
+  const res: PartialConfig = {} // Linked
   copyProps(res, config) // Creates deep clone of eta.config, 1 layer deep
 
   if (baseConfig) {

--- a/src/containers.ts
+++ b/src/containers.ts
@@ -12,6 +12,6 @@ import type { TemplateFunction } from './compile'
  * Stores partials and cached templates
  */
 
-var templates = new Cacher<TemplateFunction>({})
+const templates = new Cacher<TemplateFunction>({})
 
 export { templates }

--- a/src/err.ts
+++ b/src/err.ts
@@ -23,7 +23,7 @@ function setPrototypeOf(obj: any, proto: any) {
  */
 
 export default function EtaErr(message: string): Error {
-  var err = new Error(message)
+  const err = new Error(message)
   setPrototypeOf(err, EtaErr.prototype)
   return err
 }
@@ -37,10 +37,10 @@ EtaErr.prototype = Object.create(Error.prototype, {
  */
 
 export function ParseErr(message: string, str: string, indx: number): void {
-  var whitespace = str.slice(0, indx).split(/\n/)
+  const whitespace = str.slice(0, indx).split(/\n/)
 
-  var lineNo = whitespace.length
-  var colNo = whitespace[lineNo - 1].length + 1
+  const lineNo = whitespace.length
+  const colNo = whitespace[lineNo - 1].length + 1
   message +=
     ' at line ' +
     lineNo +

--- a/src/file-handlers.ts
+++ b/src/file-handlers.ts
@@ -41,10 +41,10 @@ export function loadFile(
   options: PartialConfigWithFilename,
   noCache?: boolean
 ): TemplateFunction {
-  var config = getConfig(options)
-  var template = readFile(filePath)
+  const config = getConfig(options)
+  const template = readFile(filePath)
   try {
-    var compiledTemplate = compile(template, config)
+    const compiledTemplate = compile(template, config)
     if (!noCache) {
       config.templates.define((config as EtaConfigWithFilename).filename, compiledTemplate)
     }
@@ -66,10 +66,10 @@ export function loadFile(
  */
 
 function handleCache(options: EtaConfigWithFilename): TemplateFunction {
-  var filename = options.filename
+  const filename = options.filename
 
   if (options.cache) {
-    var func = options.templates.get(filename)
+    const func = options.templates.get(filename)
     if (func) {
       return func
     }
@@ -96,7 +96,7 @@ function tryHandleCache(data: object, options: EtaConfigWithFilename, cb: Callba
     try {
       // Note: if there is an error while rendering the template,
       // It will bubble up and be caught here
-      var templateFn = handleCache(options)
+      const templateFn = handleCache(options)
       templateFn(data, options, cb)
     } catch (err) {
       return cb(err)
@@ -106,8 +106,8 @@ function tryHandleCache(data: object, options: EtaConfigWithFilename, cb: Callba
     if (typeof promiseImpl === 'function') {
       return new promiseImpl<string>(function (resolve: Function, reject: Function) {
         try {
-          var templateFn = handleCache(options)
-          var result = templateFn(data, options)
+          const templateFn = handleCache(options)
+          const result = templateFn(data, options)
           resolve(result)
         } catch (err) {
           reject(err)
@@ -138,7 +138,7 @@ function tryHandleCache(data: object, options: EtaConfigWithFilename, cb: Callba
 
 function includeFile(path: string, options: EtaConfig): [TemplateFunction, EtaConfig] {
   // the below creates a new options object, using the parent filepath of the old options object and the path
-  var newFileOptions = getConfig({ filename: getPath(path, options) }, options)
+  const newFileOptions = getConfig({ filename: getPath(path, options) }, options)
   // TODO: make sure properties are currectly copied over
   return [handleCache(newFileOptions as EtaConfigWithFilename), newFileOptions]
 }
@@ -226,7 +226,7 @@ function renderFile(
       }
       // Undocumented after Express 2, but still usable, esp. for
       // items that are unsafe to be passed along with data, like `root`
-      var viewOpts = data.settings['view options']
+      const viewOpts = data.settings['view options']
 
       if (viewOpts) {
         copyProps(renderConfig, viewOpts)

--- a/src/file-handlers.ts
+++ b/src/file-handlers.ts
@@ -193,8 +193,8 @@ function renderFile(
   And we want to also make (filename, data, options, cb) available
   */
 
-  var renderConfig: EtaConfigWithFilename
-  var callback: CallbackFn | undefined
+  let renderConfig: EtaConfigWithFilename
+  let callback: CallbackFn | undefined
   data = data || {} // If data is undefined, we don't want accessing data.settings to error
 
   // First, assign our callback function to `callback`

--- a/src/file-helpers.ts
+++ b/src/file-helpers.ts
@@ -15,6 +15,6 @@ interface GenericData {
  */
 
 export function includeFileHelper(this: EtaConfig, path: string, data: GenericData): string {
-  var templateAndConfig = includeFile(path, this)
+  const templateAndConfig = includeFile(path, this)
   return templateAndConfig[0](data, templateAndConfig[1])
 }

--- a/src/file-methods.deno.ts
+++ b/src/file-methods.deno.ts
@@ -1,4 +1,4 @@
 export * as fs from "https://deno.land/std@0.66.0/fs/mod.ts"
 export * as path from "https://deno.land/std@0.66.0/path/mod.ts"
 
-export var readFileSync = Deno.readTextFileSync
+export const readFileSync = Deno.readTextFileSync

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -24,9 +24,14 @@ import type { EtaConfig } from './config'
  */
 
 function getWholeFilePath(name: string, parentfile: string, isDirectory?: boolean): string {
-  const includePath =
-    path.resolve(isDirectory ? parentfile : path.dirname(parentfile)) +
-    (path.extname(name) || '.eta')
+  let includePath = path.resolve(
+    isDirectory ? parentfile : path.dirname(parentfile), // returns directory the parent file is in
+    name // file
+  )
+  const ext = path.extname(name)
+  if (!ext) {
+    includePath += '.eta'
+  }
   return includePath
 }
 

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -24,9 +24,9 @@ import type { EtaConfig } from './config'
  */
 
 function getWholeFilePath(name: string, parentfile: string, isDirectory?: boolean): string {
-  const includePath = path.resolve(
-    isDirectory ?parentfile : path.dirname(parentfile)
-  ) + (path.extname(name) || '.eta')
+  const includePath =
+    path.resolve(isDirectory ? parentfile : path.dirname(parentfile)) +
+    (path.extname(name) || '.eta')
   return includePath
 }
 

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -24,7 +24,7 @@ import type { EtaConfig } from './config'
  */
 
 function getWholeFilePath(name: string, parentfile: string, isDirectory?: boolean): string {
-  var includePath = path.resolve(
+  let includePath = path.resolve(
     isDirectory ? parentfile : path.dirname(parentfile), // returns directory the parent file is in
     name // file
   )
@@ -54,9 +54,9 @@ function getWholeFilePath(name: string, parentfile: string, isDirectory?: boolea
  */
 
 function getPath(path: string, options: EtaConfig): string {
-  var includePath: string | false = false
+  let includePath: string | false = false
   const views = options.views
-  var searchedPaths: Array<string> = []
+  let searchedPaths: Array<string> = []
 
   // If these four values are the same,
   // getPath() will return the same result every time.
@@ -90,7 +90,7 @@ function getPath(path: string, options: EtaConfig): string {
    */
 
   function searchViews(views: Array<string> | string | undefined, path: string): string | false {
-    var filePath
+    let filePath
 
     // If views is an array, then loop through each directory
     // And attempt to find the template

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -1,5 +1,5 @@
 import { fs, path, readFileSync } from './file-methods'
-var _BOM = /^\uFEFF/
+const _BOM = /^\uFEFF/
 
 // express is set like: app.engine('html', require('eta').renderFile)
 
@@ -28,7 +28,7 @@ function getWholeFilePath(name: string, parentfile: string, isDirectory?: boolea
     isDirectory ? parentfile : path.dirname(parentfile), // returns directory the parent file is in
     name // file
   )
-  var ext = path.extname(name)
+  const ext = path.extname(name)
   if (!ext) {
     includePath += '.eta'
   }
@@ -55,14 +55,14 @@ function getWholeFilePath(name: string, parentfile: string, isDirectory?: boolea
 
 function getPath(path: string, options: EtaConfig): string {
   var includePath: string | false = false
-  var views = options.views
+  const views = options.views
   var searchedPaths: Array<string> = []
 
   // If these four values are the same,
   // getPath() will return the same result every time.
   // We can cache the result to avoid expensive
   // file operations.
-  var pathOptions = JSON.stringify({
+  const pathOptions = JSON.stringify({
     filename: options.filename, // filename of the template which called includeFile()
     path: path,
     root: options.root,
@@ -123,20 +123,20 @@ function getPath(path: string, options: EtaConfig): string {
   }
 
   // Path starts with '/', 'C:\', etc.
-  var match = /^[A-Za-z]+:\\|^\//.exec(path)
+  const match = /^[A-Za-z]+:\\|^\//.exec(path)
 
   // Absolute path, like /partials/partial.eta
   if (match && match.length) {
     // We have to trim the beginning '/' off the path, or else
     // path.resolve(dir, path) will always resolve to just path
-    var formattedPath = path.replace(/^\/*/, '')
+    const formattedPath = path.replace(/^\/*/, '')
 
     // First, try to resolve the path within options.views
     includePath = searchViews(views, formattedPath)
     if (!includePath) {
       // If that fails, searchViews will return false. Try to find the path
       // inside options.root (by default '/', the base of the filesystem)
-      var pathFromRoot = getWholeFilePath(formattedPath, options.root || '/', true)
+      const pathFromRoot = getWholeFilePath(formattedPath, options.root || '/', true)
 
       addPathToSearched(pathFromRoot)
 
@@ -146,7 +146,7 @@ function getPath(path: string, options: EtaConfig): string {
     // Relative paths
     // Look relative to a passed filename first
     if (options.filename) {
-      var filePath = getWholeFilePath(path, options.filename)
+      const filePath = getWholeFilePath(path, options.filename)
 
       addPathToSearched(filePath)
 

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -24,14 +24,10 @@ import type { EtaConfig } from './config'
  */
 
 function getWholeFilePath(name: string, parentfile: string, isDirectory?: boolean): string {
-  let includePath = path.resolve(
+  const includePath = path.resolve(
     isDirectory ? parentfile : path.dirname(parentfile), // returns directory the parent file is in
     name // file
-  )
-  const ext = path.extname(name)
-  if (!ext) {
-    includePath += '.eta'
-  }
+  ) + (path.extname(name) ? '' : '.eta')
   return includePath
 }
 

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -24,14 +24,9 @@ import type { EtaConfig } from './config'
  */
 
 function getWholeFilePath(name: string, parentfile: string, isDirectory?: boolean): string {
-  let includePath = path.resolve(
-    isDirectory ? parentfile : path.dirname(parentfile), // returns directory the parent file is in
-    name // file
-  )
-  const ext = path.extname(name)
-  if (!ext) {
-    includePath += '.eta'
-  }
+  const includePath = path.resolve(
+    isDirectory ?parentfile : path.dirname(parentfile)
+  ) + (path.extname(name) || '.eta')
   return includePath
 }
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -30,13 +30,13 @@ function escapeRegExp(string: string) {
 }
 
 export default function parse(str: string, config: EtaConfig): Array<AstObject> {
-  var buffer: Array<AstObject> = []
-  var trimLeftOfNextStr: string | false = false
-  var lastIndex = 0
+  let buffer: Array<AstObject> = []
+  let trimLeftOfNextStr: string | false = false
+  let lastIndex = 0
   const parseOptions = config.parse
 
   if (config.plugins) {
-    for (var i = 0; i < config.plugins.length; i++) {
+    for (let i = 0; i < config.plugins.length; i++) {
       const plugin = config.plugins[i]
       if (plugin.processTemplate) {
         str = plugin.processTemplate(str, config)
@@ -108,7 +108,7 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
   )
   // TODO: benchmark having the \s* on either side vs using str.trim()
 
-  var m
+  let m
 
   while ((m = parseOpenReg.exec(str))) {
     lastIndex = m[0].length + m.index
@@ -120,18 +120,18 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
     pushString(precedingString, wsLeft)
 
     parseCloseReg.lastIndex = lastIndex
-    var closeTag
-    var currentObj: AstObject | false = false
+    let closeTag
+    let currentObj: AstObject | false = false
 
     while ((closeTag = parseCloseReg.exec(str))) {
       if (closeTag[1]) {
-        var content = str.slice(lastIndex, closeTag.index)
+        let content = str.slice(lastIndex, closeTag.index)
 
         parseOpenReg.lastIndex = lastIndex = parseCloseReg.lastIndex
 
         trimLeftOfNextStr = closeTag[2]
 
-        var currentType: TagType = ''
+        let currentType: TagType = ''
         if (prefix === parseOptions.exec) {
           currentType = 'e'
         } else if (prefix === parseOptions.raw) {
@@ -190,7 +190,7 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
   pushString(str.slice(lastIndex, str.length), false)
 
   if (config.plugins) {
-    for (var i = 0; i < config.plugins.length; i++) {
+    for (let i = 0; i < config.plugins.length; i++) {
       const plugin = config.plugins[i]
       if (plugin.processAST) {
         buffer = plugin.processAST(buffer, config)

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -131,7 +131,14 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
 
         trimLeftOfNextStr = closeTag[2]
 
-        const currentType: TagType = prefix === parseOptions.exec ? 'e' : (prefix === parseOptions.raw ? 'r' : (prefix === parseOptions.interpolate ? 'i' : ''))
+        const currentType: TagType =
+          prefix === parseOptions.exec
+            ? 'e'
+            : prefix === parseOptions.raw
+            ? 'r'
+            : prefix === parseOptions.interpolate
+            ? 'i'
+            : ''
 
         currentObj = { t: currentType, val: content }
         break

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -16,11 +16,11 @@ export type AstObject = string | TemplateObject
 
 /* END TYPES */
 
-var templateLitReg = /`(?:\\[\s\S]|\${(?:[^{}]|{(?:[^{}]|{[^}]*})*})*}|(?!\${)[^\\`])*`/g
+const templateLitReg = /`(?:\\[\s\S]|\${(?:[^{}]|{(?:[^{}]|{[^}]*})*})*}|(?!\${)[^\\`])*`/g
 
-var singleQuoteReg = /'(?:\\[\s\w"'\\`]|[^\n\r'\\])*?'/g
+const singleQuoteReg = /'(?:\\[\s\w"'\\`]|[^\n\r'\\])*?'/g
 
-var doubleQuoteReg = /"(?:\\[\s\w"'\\`]|[^\n\r"\\])*?"/g
+const doubleQuoteReg = /"(?:\\[\s\w"'\\`]|[^\n\r"\\])*?"/g
 
 /** Escape special regular expression characters inside a string */
 
@@ -33,11 +33,11 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
   var buffer: Array<AstObject> = []
   var trimLeftOfNextStr: string | false = false
   var lastIndex = 0
-  var parseOptions = config.parse
+  const parseOptions = config.parse
 
   if (config.plugins) {
     for (var i = 0; i < config.plugins.length; i++) {
-      var plugin = config.plugins[i]
+      const plugin = config.plugins[i]
       if (plugin.processTemplate) {
         str = plugin.processTemplate(str, config)
       }
@@ -81,7 +81,7 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
     }
   }
 
-  var prefixes = [parseOptions.exec, parseOptions.interpolate, parseOptions.raw].reduce(function (
+  const prefixes = [parseOptions.exec, parseOptions.interpolate, parseOptions.raw].reduce(function (
     accumulator,
     prefix
   ) {
@@ -97,12 +97,12 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
   },
   '')
 
-  var parseOpenReg = new RegExp(
+  const parseOpenReg = new RegExp(
     '([^]*?)' + escapeRegExp(config.tags[0]) + '(-|_)?\\s*(' + prefixes + ')?\\s*',
     'g'
   )
 
-  var parseCloseReg = new RegExp(
+  const parseCloseReg = new RegExp(
     '\'|"|`|\\/\\*|(\\s*(-|_)?' + escapeRegExp(config.tags[1]) + ')',
     'g'
   )
@@ -113,9 +113,9 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
   while ((m = parseOpenReg.exec(str))) {
     lastIndex = m[0].length + m.index
 
-    var precedingString = m[1]
-    var wsLeft = m[2]
-    var prefix = m[3] || '' // by default either ~, =, or empty
+    const precedingString = m[1]
+    const wsLeft = m[2]
+    const prefix = m[3] || '' // by default either ~, =, or empty
 
     pushString(precedingString, wsLeft)
 
@@ -143,9 +143,9 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
         currentObj = { t: currentType, val: content }
         break
       } else {
-        var char = closeTag[0]
+        const char = closeTag[0]
         if (char === '/*') {
-          var commentCloseInd = str.indexOf('*/', parseCloseReg.lastIndex)
+          const commentCloseInd = str.indexOf('*/', parseCloseReg.lastIndex)
 
           if (commentCloseInd === -1) {
             ParseErr('unclosed comment', str, closeTag.index)
@@ -154,7 +154,7 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
         } else if (char === "'") {
           singleQuoteReg.lastIndex = closeTag.index
 
-          var singleQuoteMatch = singleQuoteReg.exec(str)
+          const singleQuoteMatch = singleQuoteReg.exec(str)
           if (singleQuoteMatch) {
             parseCloseReg.lastIndex = singleQuoteReg.lastIndex
           } else {
@@ -162,7 +162,7 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
           }
         } else if (char === '"') {
           doubleQuoteReg.lastIndex = closeTag.index
-          var doubleQuoteMatch = doubleQuoteReg.exec(str)
+          const doubleQuoteMatch = doubleQuoteReg.exec(str)
 
           if (doubleQuoteMatch) {
             parseCloseReg.lastIndex = doubleQuoteReg.lastIndex
@@ -171,7 +171,7 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
           }
         } else if (char === '`') {
           templateLitReg.lastIndex = closeTag.index
-          var templateLitMatch = templateLitReg.exec(str)
+          const templateLitMatch = templateLitReg.exec(str)
           if (templateLitMatch) {
             parseCloseReg.lastIndex = templateLitReg.lastIndex
           } else {
@@ -191,7 +191,7 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
 
   if (config.plugins) {
     for (var i = 0; i < config.plugins.length; i++) {
-      var plugin = config.plugins[i]
+      const plugin = config.plugins[i]
       if (plugin.processAST) {
         buffer = plugin.processAST(buffer, config)
       }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -131,14 +131,7 @@ export default function parse(str: string, config: EtaConfig): Array<AstObject> 
 
         trimLeftOfNextStr = closeTag[2]
 
-        let currentType: TagType = ''
-        if (prefix === parseOptions.exec) {
-          currentType = 'e'
-        } else if (prefix === parseOptions.raw) {
-          currentType = 'r'
-        } else if (prefix === parseOptions.interpolate) {
-          currentType = 'i'
-        }
+        const currentType: TagType = prefix === parseOptions.exec ? 'e' : (prefix === parseOptions.raw ? 'r' : (prefix === parseOptions.interpolate ? 'i' : ''))
 
         currentObj = { t: currentType, val: content }
         break

--- a/src/polyfills.deno.ts
+++ b/src/polyfills.deno.ts
@@ -1,4 +1,4 @@
-export var promiseImpl = Promise
+export const promiseImpl = Promise
 
 export function getAsyncFunctionConstructor (): Function {
   return async function () {}.constructor

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -4,7 +4,7 @@ import EtaErr from './err'
  * @returns The global Promise function
  */
 
-export var promiseImpl: PromiseConstructor = new Function('return this')().Promise
+export const promiseImpl: PromiseConstructor = new Function('return this')().Promise
 
 /**
  * @returns A new AsyncFunction constuctor

--- a/src/render.ts
+++ b/src/render.ts
@@ -58,7 +58,7 @@ export default function render(
   config?: PartialConfig,
   cb?: CallbackFn
 ): string | Promise<string> | void {
-  var options = getConfig(config || {})
+  const options = getConfig(config || {})
 
   if (options.async) {
     var result
@@ -67,7 +67,7 @@ export default function render(
       try {
         // Note: if there is an error while rendering the template,
         // It will bubble up and be caught here
-        var templateFn = handleCache(template, options)
+        const templateFn = handleCache(template, options)
         templateFn(data, options, cb)
       } catch (err) {
         return cb(err)

--- a/src/render.ts
+++ b/src/render.ts
@@ -12,17 +12,11 @@ import type { CallbackFn } from './file-handlers'
 /* END TYPES */
 
 function handleCache(template: string | TemplateFunction, options: EtaConfig): TemplateFunction {
-  let templateFunc
-
   if (options.cache && options.name && options.templates.get(options.name)) {
     return options.templates.get(options.name)
   }
 
-  if (typeof template === 'function') {
-    templateFunc = template
-  } else {
-    templateFunc = compile(template, options)
-  }
+  const templateFunc = typeof template === 'function' ? template : compile(template, options)
 
   // Note that we don't have to check if it already exists in the cache;
   // it would have returned earlier if it had

--- a/src/render.ts
+++ b/src/render.ts
@@ -55,7 +55,6 @@ export default function render(
   const options = getConfig(config || {})
 
   if (options.async) {
-    let result
     if (cb) {
       // If user passes callback
       try {
@@ -71,8 +70,7 @@ export default function render(
       if (typeof promiseImpl === 'function') {
         return new promiseImpl(function (resolve: Function, reject: Function) {
           try {
-            result = handleCache(template, options)(data, options)
-            resolve(result)
+            resolve(handleCache(template, options)(data, options))
           } catch (err) {
             reject(err)
           }

--- a/src/render.ts
+++ b/src/render.ts
@@ -12,7 +12,7 @@ import type { CallbackFn } from './file-handlers'
 /* END TYPES */
 
 function handleCache(template: string | TemplateFunction, options: EtaConfig): TemplateFunction {
-  var templateFunc
+  let templateFunc
 
   if (options.cache && options.name && options.templates.get(options.name)) {
     return options.templates.get(options.name)
@@ -61,7 +61,7 @@ export default function render(
   const options = getConfig(config || {})
 
   if (options.async) {
-    var result
+    let result
     if (cb) {
       // If user passes callback
       try {

--- a/src/render.ts
+++ b/src/render.ts
@@ -86,7 +86,12 @@ export default function render(
   }
 }
 
-export function renderAsync(template: string | TemplateFunction, data: object, config?: PartialConfig, cb?: CallbackFn): string | Promise<string> | void {
+export function renderAsync(
+  template: string | TemplateFunction,
+  data: object,
+  config?: PartialConfig,
+  cb?: CallbackFn
+): string | Promise<string> | void {
   // Using Object.assign to lower bundle size, using spread operator makes it larger
   return render(template, data, Object.assign({}, config, { async: true }), cb)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,7 @@ export function hasOwnProp(obj: object, prop: string): boolean {
 }
 
 export function copyProps<T>(toObj: T, fromObj: T): T {
-  for (var key in fromObj) {
+  for (const key in fromObj) {
     if (hasOwnProp((fromObj as unknown) as object, key)) {
       toObj[key] = fromObj[key]
     }
@@ -94,7 +94,7 @@ function trimWS(
  * A map of special HTML characters to their XML-escaped equivalents
  */
 
-var escMap: EscapeMap = {
+const escMap: EscapeMap = {
   '&': '&amp;',
   '<': '&lt;',
   '>': '&gt;',
@@ -116,7 +116,7 @@ function replaceChar(s: string): string {
 function XMLEscape(str: any): string {
   // eslint-disable-line @typescript-eslint/no-explicit-any
   // To deal with XSS. Based on Escape implementations of Mustache.JS and Marko, then customized.
-  var newStr = String(str)
+  const newStr = String(str)
   if (/[&<>"']/.test(newStr)) {
     return newStr.replace(/[&<>"']/g, replaceChar)
   } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,8 +41,8 @@ function trimWS(
   wsLeft: string | false,
   wsRight?: string | false
 ): string {
-  var leftTrim
-  var rightTrim
+  let leftTrim
+  let rightTrim
 
   if (Array.isArray(config.autoTrim)) {
     // kinda confusing

--- a/test/compile-string.spec.ts
+++ b/test/compile-string.spec.ts
@@ -1,7 +1,7 @@
 /* global it, expect, describe */
 import { compileToString, defaultConfig, getConfig } from '../src/index'
 
-var fs = require('fs'),
+const fs = require('fs'),
   path = require('path'),
   filePath = path.join(__dirname, 'templates/complex.eta')
 
@@ -9,7 +9,7 @@ const complexTemplate = fs.readFileSync(filePath, 'utf8')
 
 describe('Compile to String test', () => {
   it('parses a simple template', () => {
-    var str = compileToString('hi <%= hey %>', defaultConfig)
+    const str = compileToString('hi <%= hey %>', defaultConfig)
     expect(str)
       .toEqual(`var tR='',__l,__lP,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
 function layout(p,d){__l=p;__lP=d}
@@ -20,7 +20,7 @@ if(cb){cb(null,tR)} return tR`)
   })
 
   it('parses a simple template without partial helpers defined', () => {
-    var str = compileToString(
+    const str = compileToString(
       'hi <%= hey %>',
       getConfig({ include: undefined, includeFile: undefined })
     )
@@ -32,7 +32,7 @@ if(cb){cb(null,tR)} return tR`)
   })
 
   it('parses a simple template with raw tag', () => {
-    var str = compileToString('hi <%~ hey %>', defaultConfig)
+    const str = compileToString('hi <%~ hey %>', defaultConfig)
     expect(str)
       .toEqual(`var tR='',__l,__lP,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
 function layout(p,d){__l=p;__lP=d}
@@ -43,7 +43,7 @@ if(cb){cb(null,tR)} return tR`)
   })
 
   it('works with whitespace trimming', () => {
-    var str = compileToString('hi\n<%- = hey-%>\n<%_ = hi_%>', defaultConfig)
+    const str = compileToString('hi\n<%- = hey-%>\n<%_ = hi_%>', defaultConfig)
     expect(str)
       .toEqual(`var tR='',__l,__lP,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
 function layout(p,d){__l=p;__lP=d}
@@ -55,7 +55,7 @@ if(cb){cb(null,tR)} return tR`)
   })
 
   it('compiles complex template', () => {
-    var str = compileToString(complexTemplate, defaultConfig)
+    const str = compileToString(complexTemplate, defaultConfig)
     expect(str).toEqual(
       `var tR='',__l,__lP,include=E.include.bind(E),includeFile=E.includeFile.bind(E)
 function layout(p,d){__l=p;__lP=d}

--- a/test/compile.spec.ts
+++ b/test/compile.spec.ts
@@ -3,7 +3,7 @@
 import { compile } from '../src/index'
 import { buildRegEx } from './err.spec'
 
-var fs = require('fs'),
+const fs = require('fs'),
   path = require('path'),
   filePath = path.join(__dirname, 'templates/complex.eta')
 
@@ -11,18 +11,18 @@ const complexTemplate = fs.readFileSync(filePath, 'utf8')
 
 describe('Compile test', () => {
   it('parses a simple template', () => {
-    var str = compile('hi <%= hey %>')
+    const str = compile('hi <%= hey %>')
     expect(str).toBeTruthy()
   })
 
   it('works with plain string templates', () => {
-    var str = compile('hi this is a template')
+    const str = compile('hi this is a template')
     expect(str).toBeTruthy()
   })
 
   // TODO: Update
   it('compiles complex template', () => {
-    var str = compile(complexTemplate)
+    const str = compile(complexTemplate)
     expect(str).toBeTruthy()
   })
 

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -5,17 +5,17 @@ import { config, configure, getConfig } from '../src/config'
 
 describe('Config Tests', () => {
   it('Renders a simple template with default env', () => {
-    var res = render('hi <%= it.name %>', { name: 'Ben' }, defaultConfig)
+    const res = render('hi <%= it.name %>', { name: 'Ben' }, defaultConfig)
     expect(res).toEqual('hi Ben')
   })
 
   it('Renders a simple template with custom tags', () => {
-    var res = render('hi <<= it.name >>', { name: 'Ben' }, { tags: ['<<', '>>'] })
+    const res = render('hi <<= it.name >>', { name: 'Ben' }, { tags: ['<<', '>>'] })
     expect(res).toEqual('hi Ben')
   })
 
   it('Renders a simple template with stored env', () => {
-    var res = render('<%= it.html %>', { html: '<p>Hi</p>' }, { autoEscape: false })
+    const res = render('<%= it.html %>', { html: '<p>Hi</p>' }, { autoEscape: false })
     expect(res).toEqual('<p>Hi</p>') // not escaped
   })
 
@@ -57,9 +57,9 @@ describe('Config Tests', () => {
   })
 
   it('Configure command works', () => {
-    var updatedConfig = configure({ tags: ['{{', '}}'] })
+    const updatedConfig = configure({ tags: ['{{', '}}'] })
 
-    var res = render('{{= it.name }}', { name: 'John Appleseed' })
+    const res = render('{{= it.name }}', { name: 'John Appleseed' })
     expect(res).toEqual('John Appleseed')
 
     expect(defaultConfig).toEqual(updatedConfig)

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -20,7 +20,7 @@ describe('Config Tests', () => {
   })
 
   it('config.filter works', () => {
-    let template = 'My favorite food is <%= it.fav %>'
+    const template = 'My favorite food is <%= it.fav %>'
 
     expect(render(template, {})).toEqual('My favorite food is undefined')
 

--- a/test/deno/config.spec.ts
+++ b/test/deno/config.spec.ts
@@ -2,19 +2,19 @@ import { assertEquals } from 'https://deno.land/std@0.67.0/testing/asserts.ts'
 import * as eta from '../../deno_dist/mod.ts'
 
 Deno.test('Renders a simple template with default env', () => {
-  var res = eta.render('hi <%= it.name %>', { name: 'Ben' }, eta.defaultConfig)
+  const res = eta.render('hi <%= it.name %>', { name: 'Ben' }, eta.defaultConfig)
 
   assertEquals(res, 'hi Ben')
 })
 
 Deno.test('Renders a simple template with custom tags', () => {
-  var res = eta.render('hi <<= it.name >>', { name: 'Ben' }, { tags: ['<<', '>>'] })
+  const res = eta.render('hi <<= it.name >>', { name: 'Ben' }, { tags: ['<<', '>>'] })
 
   assertEquals(res, 'hi Ben')
 })
 
 Deno.test('Renders a simple template without autoescaping', () => {
-  var res = eta.render('<%= it.html %>', { html: '<p>Hi</p>' }, { autoEscape: false })
+  const res = eta.render('<%= it.html %>', { html: '<p>Hi</p>' }, { autoEscape: false })
 
   assertEquals(res, '<p>Hi</p>') // not escaped
 })

--- a/test/deno/file-helpers.spec.ts
+++ b/test/deno/file-helpers.spec.ts
@@ -7,13 +7,13 @@ import { render, templates, compile } from '../../deno_dist/mod.ts'
 templates.define('test-template', compile('Saluton <%=it.name%>'))
 
 Deno.test('include works', async () => {
-  var renderedTemplate = render('<%~ include("test-template", it) %>', { name: 'Ada' })
+  const renderedTemplate = render('<%~ include("test-template", it) %>', { name: 'Ada' })
 
   assertEquals(renderedTemplate, 'Saluton Ada')
 })
 
 Deno.test('includeFile works w/ filename prop', async () => {
-  var renderedTemplate = render(
+  const renderedTemplate = render(
     '<%~ includeFile("simple", it) %>',
     { name: 'Ada' },
     { filename: path.join(__dirname, '../templates/placeholder.eta') }
@@ -23,7 +23,7 @@ Deno.test('includeFile works w/ filename prop', async () => {
 })
 
 Deno.test('"E.includeFile" works with "views" array', async () => {
-  var renderedTemplate = render(
+  const renderedTemplate = render(
     '<%~ E.includeFile("randomtemplate", it) %>',
     { user: 'Ben' },
     { views: [path.join(__dirname, '../templates'), path.join(__dirname, '../othertemplates')] }
@@ -33,7 +33,7 @@ Deno.test('"E.includeFile" works with "views" array', async () => {
 })
 
 Deno.test('"includeFile" works with "views" array', async () => {
-  var renderedTemplate = render(
+  const renderedTemplate = render(
     '<%~ includeFile("randomtemplate", it) %>',
     { user: 'Ben' },
     { views: [path.join(__dirname, '../templates'), path.join(__dirname, '../othertemplates')] }
@@ -43,7 +43,7 @@ Deno.test('"includeFile" works with "views" array', async () => {
 })
 
 Deno.test('"includeFile" works with "views" string', async () => {
-  var renderedTemplate = render(
+  const renderedTemplate = render(
     '<%~ includeFile("randomtemplate", it) %>',
     { user: 'Ben' },
     { views: path.join(__dirname, '../othertemplates') }

--- a/test/deno/helpers.spec.ts
+++ b/test/deno/helpers.spec.ts
@@ -3,7 +3,7 @@ import { render } from '../../deno_dist/mod.ts'
 
 // SHOULD TEST COMMON ETA USAGE PATTERNS HERE
 
-var eachTemplate = `
+const eachTemplate = `
 The Daugherty's have 5 kids:
 <ul>
 <% it.kids.forEach(function(kid){ %>
@@ -12,7 +12,7 @@ The Daugherty's have 5 kids:
 </ul>`
 
 Deno.test('Loop over an array', () => {
-  var res = render(eachTemplate, { kids: ['Ben', 'Polly', 'Joel', 'Phronsie', 'Davie'] })
+  const res = render(eachTemplate, { kids: ['Ben', 'Polly', 'Joel', 'Phronsie', 'Davie'] })
 
   assertEquals(
     res,

--- a/test/file-handlers.spec.ts
+++ b/test/file-handlers.spec.ts
@@ -91,7 +91,7 @@ describe('Simple renderFile tests', () => {
 
 describe('File location tests', () => {
   it('locates a file with the views option', async () => {
-    let res = await renderFile(
+    const res = await renderFile(
       'simple.eta',
       { name: 'Ada' },
       { views: path.join(__dirname, 'templates') }

--- a/test/file-handlers.spec.ts
+++ b/test/file-handlers.spec.ts
@@ -4,20 +4,20 @@ import { renderFile, renderFileAsync, __express, templates, compile } from '../s
 
 import { buildRegEx } from './err.spec'
 
-var path = require('path'),
+const path = require('path'),
   filePath = path.join(__dirname, 'templates/simple.eta'),
   errFilePath = path.join(__dirname, 'templates/badsyntax.eta'),
   fakeFilePath = path.join(__dirname, 'templates/fake.eta')
 
 describe('Simple renderFile tests', () => {
   it('renders a simple template file', async () => {
-    var renderedFile = await renderFile(filePath, { name: 'Ben' })
+    const renderedFile = await renderFile(filePath, { name: 'Ben' })
 
     expect(renderedFile).toEqual('Hi Ben')
   })
 
   it('renderFile is aliased as __express', async () => {
-    var renderedFile = await __express(filePath, { name: 'Ben' })
+    const renderedFile = await __express(filePath, { name: 'Ben' })
 
     expect(renderedFile).toEqual('Hi Ben')
   })
@@ -52,12 +52,12 @@ describe('Simple renderFile tests', () => {
   })
 
   it('renders an async template using Promises', async () => {
-    var res = await renderFile(filePath, { name: 'Ada', async: true })
+    const res = await renderFile(filePath, { name: 'Ada', async: true })
     expect(res).toEqual('Hi Ada')
   })
 
   it('renders an async template with an explicit config using Promises', async () => {
-    var res = await renderFile(filePath, { name: 'Ada' }, { async: true })
+    const res = await renderFile(filePath, { name: 'Ada' }, { async: true })
     expect(res).toEqual('Hi Ada')
   })
 

--- a/test/file-helpers.spec.ts
+++ b/test/file-helpers.spec.ts
@@ -2,13 +2,13 @@
 
 import { render, templates, compile } from '../src/index'
 
-var path = require('path')
+const path = require('path')
 
 templates.define('test-template', compile('HEY <%=it.name%>'))
 
 describe('include works', () => {
   it('simple parser works with "E.includeFile"', async () => {
-    var renderedTemplate = render(
+    const renderedTemplate = render(
       '<%~ E.includeFile("simple", it) %>',
       { name: 'Ben' },
       { filename: path.join(__dirname, 'templates/placeholder.eta') }
@@ -18,7 +18,7 @@ describe('include works', () => {
   })
 
   it('simple parser works with "includeFile"', async () => {
-    var renderedTemplate = render(
+    const renderedTemplate = render(
       '<%~ includeFile("simple", it) %>',
       { name: 'Ben' },
       { filename: path.join(__dirname, 'templates/placeholder.eta') }
@@ -28,7 +28,7 @@ describe('include works', () => {
   })
 
   it('"includeFile" works with "views" array', async () => {
-    var renderedTemplate = render(
+    const renderedTemplate = render(
       '<%~ includeFile("randomtemplate", it) %>',
       { user: 'Ben' },
       {
@@ -41,7 +41,7 @@ describe('include works', () => {
   })
 
   it('simple parser works with "include"', async () => {
-    var renderedTemplate = render('<%~ include("test-template", it) %>', { name: 'Ben' })
+    const renderedTemplate = render('<%~ include("test-template", it) %>', { name: 'Ben' })
 
     expect(renderedTemplate).toEqual('HEY Ben')
   })

--- a/test/file-utils.spec.ts
+++ b/test/file-utils.spec.ts
@@ -3,7 +3,7 @@
 import { renderFile, loadFile, templates } from '../src/index'
 import { config } from '../src/config'
 
-var path = require('path'),
+const path = require('path'),
   filePath = path.join(__dirname, 'templates/simple.eta')
 
 describe('File tests', () => {

--- a/test/file-utils.spec.ts
+++ b/test/file-utils.spec.ts
@@ -19,9 +19,9 @@ describe('Filepath caching', () => {
     // This test renders templates/has-include.eta with caching enabled, then checks to make sure
     // `config.filepathCache` contains the expected result afterward
 
-    let viewsDir = path.join(__dirname, 'templates')
+    const viewsDir = path.join(__dirname, 'templates')
 
-    let templateResult = await renderFile('has-include', {}, { views: viewsDir, cache: true })
+    const templateResult = await renderFile('has-include', {}, { views: viewsDir, cache: true })
 
     expect(templateResult).toEqual(
       `This is the outermost template. Now we'll include a partial
@@ -36,11 +36,11 @@ Hi Test Runner`
     // Filepath caching is based on the premise that given the same path, includer filename, root directory, and views directory (or directories)
     // the getPath function will always return the same result (assuming that caching is enabled and we're not expecting the templates to change)
 
-    let pathToHasInclude = `{"filename":"${viewsDir}/has-include.eta","path":"./partial","views":"${viewsDir}"}`
+    const pathToHasInclude = `{"filename":"${viewsDir}/has-include.eta","path":"./partial","views":"${viewsDir}"}`
 
-    let pathToPartial = `{"filename":"${viewsDir}/partial.eta","path":"./simple","views":"${viewsDir}"}`
+    const pathToPartial = `{"filename":"${viewsDir}/partial.eta","path":"./simple","views":"${viewsDir}"}`
 
-    let pathToSimple = `{"path":"has-include","views":"${viewsDir}"}`
+    const pathToSimple = `{"path":"has-include","views":"${viewsDir}"}`
 
     expect(config.filepathCache).toEqual({
       [pathToHasInclude]: `${viewsDir}/partial.eta`,

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -4,7 +4,7 @@ import { render } from '../src/index'
 
 // SHOULD TEST COMMON ETA USAGE PATTERNS HERE
 
-var eachTemplate = `
+const eachTemplate = `
 The Daugherty's have 5 kids:
 <ul>
 <% it.kids.forEach(function(kid){ %>
@@ -14,7 +14,7 @@ The Daugherty's have 5 kids:
 
 describe('Helper tests', () => {
   it('parses a simple array foreach', () => {
-    var res = render(eachTemplate, { kids: ['Ben', 'Polly', 'Joel', 'Phronsie', 'Davie'] })
+    const res = render(eachTemplate, { kids: ['Ben', 'Polly', 'Joel', 'Phronsie', 'Davie'] })
     expect(res).toEqual(
       `
 The Daugherty's have 5 kids:

--- a/test/layouts.spec.ts
+++ b/test/layouts.spec.ts
@@ -5,7 +5,7 @@ import { compile, render, renderFile, templates } from '../src/index'
 
 describe('Layout Tests', () => {
   it('Nested layouts work as expected', async () => {
-    var res = await renderFile(
+    const res = await renderFile(
       'index.eta',
       { title: 'Cool Title' },
       // Async can be true or false
@@ -29,7 +29,7 @@ This is the template body.
       compile(`###<%= it.title %>###,<%~ it.body %>`, { includeFile: undefined })
     )
 
-    var res = await render(
+    const res = await render(
       `<% layout("my-layout") %>
 This is a layout`,
       { title: 'Cool Title' },
@@ -47,7 +47,7 @@ This is a layout`,
       })
     )
 
-    var res = await render(
+    const res = await render(
       `<% layout("my-layout", { title: 'Nifty title', content: 'Nice content'}) %>
 This is a layout`,
       { title: 'Cool Title', randomNum: 3 },

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -3,7 +3,7 @@
 import { parse } from '../src/index'
 import { config } from '../src/config'
 
-var fs = require('fs'),
+const fs = require('fs'),
   path = require('path'),
   filePath = path.join(__dirname, 'templates/complex.eta')
 
@@ -11,32 +11,32 @@ const complexTemplate = fs.readFileSync(filePath, 'utf8')
 
 describe('parse test', () => {
   it('parses a simple template', () => {
-    var buff = parse('hi <%= hey %>', config)
+    const buff = parse('hi <%= hey %>', config)
     expect(buff).toEqual(['hi ', { val: 'hey', t: 'i' }])
   })
 
   it('parses a raw tag', () => {
-    var buff = parse('hi <%~ hey %>', config)
+    const buff = parse('hi <%~ hey %>', config)
     expect(buff).toEqual(['hi ', { val: 'hey', t: 'r' }])
   })
 
   it('works with whitespace trimming', () => {
-    var buff = parse('hi\n<%- = hey-%> <%_ = hi _%>', config)
+    const buff = parse('hi\n<%- = hey-%> <%_ = hi _%>', config)
     expect(buff).toEqual(['hi', { val: 'hey', t: 'i' }, { val: 'hi', t: 'i' }])
   })
 
   it('works with multiline comments', () => {
-    var buff = parse('hi <% /* comment contains delimiter %> */ %>', config)
+    const buff = parse('hi <% /* comment contains delimiter %> */ %>', config)
     expect(buff).toEqual(['hi ', { val: '/* comment contains delimiter %> */', t: 'e' }])
   })
 
   it('parses with simple template literal', () => {
-    var buff = parse('hi <%= `template %> ${value}` %>', config)
+    const buff = parse('hi <%= `template %> ${value}` %>', config)
     expect(buff).toEqual(['hi ', { val: '`template %> ${value}`', t: 'i' }])
   })
 
   it('compiles complex template', () => {
-    var buff = parse(complexTemplate, config)
+    const buff = parse(complexTemplate, config)
     expect(buff).toEqual([
       'Hi\\n',
       { t: 'e', val: 'console.log("Hope you like Eta!")' },

--- a/test/plugins.spec.ts
+++ b/test/plugins.spec.ts
@@ -17,7 +17,7 @@ function myPlugin() {
   }
 }
 
-var template = `<%= it.val %> <%= @@num@@ %>.`
+const template = `<%= it.val %> <%= @@num@@ %>.`
 
 describe('Plugins', () => {
   it('Plugins function properly', () => {

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -21,7 +21,7 @@ describe('Simple Render checks', () => {
     })
     it('Rendering function works', async () => {
       const template = 'Hello <%= await it.getName() %>!'
-      let getName = () => {
+      const getName = () => {
         return new Promise((res) => {
           setTimeout(() => {
             res('Ada')
@@ -32,7 +32,7 @@ describe('Simple Render checks', () => {
     })
     it('Rendering async function works', async () => {
       const template = 'Hello <%= await it.getName() %>!'
-      let getName = () => {
+      const getName = () => {
         return new Promise((res) => {
           setTimeout(() => {
             res('Ada')
@@ -67,15 +67,15 @@ describe('Renders with different scopes', () => {
 
 describe('processTemplate plugin', () => {
   it('Simple plugin works correctly', () => {
-    let template = ':thumbsup:'
+    const template = ':thumbsup:'
 
-    let emojiTransform = {
+    const emojiTransform = {
       processTemplate: function (str: string) {
         return str.replace(':thumbsup:', '👍')
       }
     }
 
-    let res = render(
+    const res = render(
       template,
       {},
       {
@@ -87,27 +87,27 @@ describe('processTemplate plugin', () => {
   })
 
   it('Multiple chained plugins work correctly', () => {
-    let template = ':thumbsup: This is a cool template'
+    const template = ':thumbsup: This is a cool template'
 
-    let emojiTransform = {
+    const emojiTransform = {
       processTemplate: function (str: string) {
         return str.replace(':thumbsup:', '👍')
       }
     }
 
-    let capitalizeCool = {
+    const capitalizeCool = {
       processTemplate: function (str: string) {
         return str.replace('cool', 'COOL')
       }
     }
 
-    let replaceThumbsUp = {
+    const replaceThumbsUp = {
       processTemplate: function (str: string) {
         return str.replace('👍', '✨')
       }
     }
 
-    let res = render(
+    const res = render(
       template,
       {},
       {

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -28,7 +28,7 @@ describe('Simple Render checks', () => {
           }, 20)
         })
       }
-      expect(await render(template, { getName: getName }, { async: true })).toEqual('Hello Ada!')
+      expect(await render(template, { getName }, { async: true })).toEqual('Hello Ada!')
     })
     it('Rendering async function works', async () => {
       const template = 'Hello <%= await it.getName() %>!'

--- a/test/storage.spec.ts
+++ b/test/storage.spec.ts
@@ -2,7 +2,7 @@
 
 import { Cacher } from '../src/storage'
 
-var Container = new Cacher<number>({ one: 1, two: 2 })
+const Container = new Cacher<number>({ one: 1, two: 2 })
 
 describe('Config Tests', () => {
   it('Cache.get works', () => {


### PR DESCRIPTION
Use more `ES6` features such as `const` and `let`. Should not increase bundle size.