### PR TITLE
feat: adding globalAwait option

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,9 @@ export interface EtaConfig {
   /** A filter function applied to every interpolation or raw interpolation */
   filter?: Function
 
+  /** Adds all variables in big Promise.all and awaits for it */
+  globalAwait?: boolean
+
   /** Function to include templates by name */
   include?: Function
 


### PR DESCRIPTION
Implements feature of #99. 

This feature allows us to add all data objects in an array and to await for it globally (only when the `globalAwait` option is set to true in the config).

This adds almost no overhead at runtime (adding a for loop to generate the array push, but that's neglectable overhead), because `Promise.all` just returns the value of synchronous functions and variables and only awaits for asynchronous functions. This could even be the default behavior when resolving templates (removing the option).

This allows us to speed things up a lot when having a lot of asynchronous functions in our data object.

Because this doesn't change anything about how this template engine works and just adds some extra speed, I don't think this is an out of scope feature, it is very useful when dealing with asynchronous functions.