### PR TITLE
revert: browser es modules thing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://eta.js.org",
   "main": "dist/eta.cjs",
   "browser": "dist/browser/eta.min.js",
-  "module": "dist/browser/eta.es.min.js",
+  "module": "dist/eta.es.js",
   "type": "module",
   "exports": {
     "import": "./dist/eta.es.js",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -24,17 +24,6 @@ export default [
         name: 'Eta',
         sourcemap: true,
         plugins: [terser()]
-      },
-      {
-        file: 'dist/browser/eta.es.js',
-        format: 'es',
-        sourcemap: true
-      },
-      {
-        file: pkg.module,
-        format: 'es',
-        sourcemap: true,
-        plugins: [terser()]
       }
     ],
     plugins: [typescript({ useTsconfigDeclarationDir: true }), commonjs(), resolve()],
@@ -53,7 +42,7 @@ export default [
         sourcemap: true
       },
       {
-        file: pkg.exports.import,
+        file: pkg.module,
         format: 'es',
         sourcemap: true
       }


### PR DESCRIPTION
just revert the browser es modules thing then I can publish a long awaited patch release for removing unstable api usage with deno