### PR TITLE
Issue 146

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eta",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "Lightweight, fast, and powerful embedded JS template engine",
   "keywords": [
     "handlebars",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -24,6 +24,17 @@ export default [
         name: 'Eta',
         sourcemap: true,
         plugins: [terser()]
+      },
+      {
+        file: 'dist/browser/eta.es.dev.js',
+        format: 'es',
+        sourcemap: true
+      },
+      {
+        file: 'dist/browser/eta.es.min.js',
+        format: 'es',
+        sourcemap: true,
+        plugins: [terser()]
       }
     ],
     plugins: [typescript({ useTsconfigDeclarationDir: true }), commonjs(), resolve()],


### PR DESCRIPTION
Fixes #146

New version would be v1.12.4 as it is really a patch. No overrides will be made in `package.json` to avoid creating a 2.0 version without any bigger features/reworks happening beforehand. 