### PR TITLE
Update benchmarks link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Eta is a lightweight and blazing fast embedded JS templating engine that works i
 - ⚡️ Written in TypeScript
 - ✨ Deno support (+ Node and browser)
 - 🚀 Super Fast
-  - Check out [these benchmarks](https://ghcdn.rawgit.org/eta-dev/eta/master/browser-tests/benchmark.html)
+  - Check out [these benchmarks](https://ghcdn.rawgit.org/eta-dev/eta/694976ffcfbe5fc2e5ae3f891549849a3bba9fdd/browser-tests/benchmark.html)
 - 🔧 Configurable
   - Plugins, custom delimiters, caching
 - 🔨 Powerful

--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -44,7 +44,7 @@ emphasizes phenomenal performance, configurability, and low bundle size.
 - ✨ Deno support (+ Node and browser)
 - 🚀 Super Fast
   - Check out
-    [these benchmarks](https://ghcdn.rawgit.org/eta-dev/eta/master/browser-tests/benchmark.html)
+    [these benchmarks](https://ghcdn.rawgit.org/eta-dev/eta/694976ffcfbe5fc2e5ae3f891549849a3bba9fdd/browser-tests/benchmark.html)
 - 🔧 Configurable
   - Plugins, custom delimiters, caching
 - 🔨 Powerful


### PR DESCRIPTION
This is a follow up to #155. rawgit.org's CDN caches, so `master` will point to the first time benchmark.html was requested from rawgit. See this [FAQ](https://github.com/rgrove/rawgit/blob/master/FAQ.md#how-long-does-the-cdn-cache-files-how-can-i-make-it-refresh-my-file) for more info there.