### PR TITLE
Fix types specification in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "module": "dist/eta.es.js",
   "type": "module",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/eta.es.js",
     "require": "./dist/eta.cjs",
     "browser": "./dist/browser/eta.min.js"


### PR DESCRIPTION
TypeScript with `"moduleResolution": "node16"` can only find *.d.ts files if `types` field is specified in `exports` field (see https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing).