### PR TITLE
Improve return types for `render`, `renderAsync`, `renderFile` and `renderFileAsync`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -90,6 +90,7 @@ export interface EtaConfigWithFilename extends EtaConfig {
 }
 
 export type PartialConfig = Partial<EtaConfig>
+export type PartialAsyncConfig = PartialConfig & { async: true }
 
 /* END TYPES */
 

--- a/src/file-handlers.ts
+++ b/src/file-handlers.ts
@@ -192,8 +192,6 @@ function renderFile(
 
 function renderFile(filename: string, data: DataObj, cb: CallbackFn): void
 
-function renderFile(filename: string, data: DataObj, cb?: CallbackFn): Promise<string> | void
-
 function renderFile(
   filename: string,
   data: DataObj,
@@ -304,8 +302,6 @@ function renderFileAsync(
 ): Promise<string> | void
 
 function renderFileAsync(filename: string, data: DataObj, cb: CallbackFn): void
-
-function renderFileAsync(filename: string, data: DataObj, cb?: CallbackFn): Promise<string> | void
 
 function renderFileAsync(
   filename: string,

--- a/src/file-handlers.ts
+++ b/src/file-handlers.ts
@@ -174,8 +174,23 @@ function renderFile(
   filename: string,
   data: DataObj,
   config?: PartialConfig,
+): Promise<string>
+
+function renderFile(
+  filename: string,
+  data: DataObj,
+  config: PartialConfig,
+  cb: CallbackFn
+): void
+
+function renderFile(
+  filename: string,
+  data: DataObj,
+  config?: PartialConfig,
   cb?: CallbackFn
 ): Promise<string> | void
+
+function renderFile(filename: string, data: DataObj, cb: CallbackFn): void
 
 function renderFile(filename: string, data: DataObj, cb?: CallbackFn): Promise<string> | void
 
@@ -271,9 +286,24 @@ function renderFile(
 function renderFileAsync(
   filename: string,
   data: DataObj,
+  config?: PartialConfig
+): Promise<string>
+
+function renderFileAsync(
+  filename: string,
+  data: DataObj,
+  config: PartialConfig,
+  cb: CallbackFn
+): void
+
+function renderFileAsync(
+  filename: string,
+  data: DataObj,
   config?: PartialConfig,
   cb?: CallbackFn
 ): Promise<string> | void
+
+function renderFileAsync(filename: string, data: DataObj, cb: CallbackFn): void
 
 function renderFileAsync(filename: string, data: DataObj, cb?: CallbackFn): Promise<string> | void
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -173,8 +173,54 @@ export default function render(
  * @param template Template string or template function
  * @param data Data to render the template with
  * @param config Optional config options
+ */
+export function renderAsync(
+    template: string | TemplateFunction,
+    data: object,
+    config?: PartialConfig
+): Promise<string>;
+
+/**
+ * Render a template asynchronously
+ *
+ * If `template` is a string, Eta will compile it to a function and call it with the provided data.
+ * If `template` is a function, Eta will call it with the provided data.
+ *
+ * If there is a callback function, Eta will call it with `(err, renderedTemplate)`.
+ * If there is not a callback function, Eta will return a Promise that resolves to the rendered template
+ *
+ * @param template Template string or template function
+ * @param data Data to render the template with
+ * @param config Optional config options
  * @param cb Callback function
  */
+export function renderAsync(
+    template: string | TemplateFunction,
+    data: object,
+    config: PartialConfig,
+    cb: CallbackFn
+): void;
+
+/**
+ * Render a template asynchronously
+ *
+ * If `template` is a string, Eta will compile it to a function and call it with the provided data.
+ * If `template` is a function, Eta will call it with the provided data.
+ *
+ * If there is a callback function, Eta will call it with `(err, renderedTemplate)`.
+ * If there is not a callback function, Eta will return a Promise that resolves to the rendered template
+ *
+ * @param template Template string or template function
+ * @param data Data to render the template with
+ * @param config Optional config options
+ * @param cb Callback function
+ */
+export function renderAsync(
+    template: string | TemplateFunction,
+    data: object,
+    config?: PartialConfig,
+    cb?: CallbackFn
+): string | Promise<string> | void;
 
 export function renderAsync(
   template: string | TemplateFunction,

--- a/src/render.ts
+++ b/src/render.ts
@@ -50,7 +50,7 @@ export default function render(
     data: object,
     config: PartialAsyncConfig,
     cb: CallbackFn
-): void;
+): void
 
 /**
  * Render a template
@@ -73,7 +73,7 @@ export default function render(
     template: string | TemplateFunction,
     data: object,
     config: PartialAsyncConfig
-): Promise<string>;
+): Promise<string>
 
 /**
  * Render a template
@@ -96,7 +96,7 @@ export default function render(
     template: string | TemplateFunction,
     data: object,
     config?: PartialConfig
-): string;
+): string
 
 /**
  * Render a template
@@ -121,7 +121,7 @@ export default function render(
     data: object,
     config?: PartialConfig,
     cb?: CallbackFn
-): string | Promise<string> | void;
+): string | Promise<string> | void
 
 export default function render(
   template: string | TemplateFunction,
@@ -178,7 +178,7 @@ export function renderAsync(
     template: string | TemplateFunction,
     data: object,
     config?: PartialConfig
-): Promise<string>;
+): Promise<string>
 
 /**
  * Render a template asynchronously
@@ -199,7 +199,7 @@ export function renderAsync(
     data: object,
     config: PartialConfig,
     cb: CallbackFn
-): void;
+): void
 
 /**
  * Render a template asynchronously
@@ -220,7 +220,7 @@ export function renderAsync(
     data: object,
     config?: PartialConfig,
     cb?: CallbackFn
-): string | Promise<string> | void;
+): string | Promise<string> | void
 
 export function renderAsync(
   template: string | TemplateFunction,

--- a/src/render.ts
+++ b/src/render.ts
@@ -5,7 +5,7 @@ import EtaErr from './err'
 
 /* TYPES */
 
-import type { EtaConfig, PartialConfig } from './config'
+import type { EtaConfig, PartialConfig, PartialAsyncConfig } from './config'
 import type { TemplateFunction } from './compile'
 import type { CallbackFn } from './file-handlers'
 
@@ -45,6 +45,83 @@ function handleCache(template: string | TemplateFunction, options: EtaConfig): T
  * @param config Optional config options
  * @param cb Callback function
  */
+export default function render(
+    template: string | TemplateFunction,
+    data: object,
+    config: PartialAsyncConfig,
+    cb: CallbackFn
+): void;
+
+/**
+ * Render a template
+ *
+ * If `template` is a string, Eta will compile it to a function and then call it with the provided data.
+ * If `template` is a template function, Eta will call it with the provided data.
+ *
+ * If `config.async` is `false`, Eta will return the rendered template.
+ *
+ * If `config.async` is `true` and there's a callback function, Eta will call the callback with `(err, renderedTemplate)`.
+ * If `config.async` is `true` and there's not a callback function, Eta will return a Promise that resolves to the rendered template.
+ *
+ * If `config.cache` is `true` and `config` has a `name` or `filename` property, Eta will cache the template on the first render and use the cached template for all subsequent renders.
+ *
+ * @param template Template string or template function
+ * @param data Data to render the template with
+ * @param config Optional config options
+ */
+export default function render(
+    template: string | TemplateFunction,
+    data: object,
+    config: PartialAsyncConfig
+): Promise<string>;
+
+/**
+ * Render a template
+ *
+ * If `template` is a string, Eta will compile it to a function and then call it with the provided data.
+ * If `template` is a template function, Eta will call it with the provided data.
+ *
+ * If `config.async` is `false`, Eta will return the rendered template.
+ *
+ * If `config.async` is `true` and there's a callback function, Eta will call the callback with `(err, renderedTemplate)`.
+ * If `config.async` is `true` and there's not a callback function, Eta will return a Promise that resolves to the rendered template.
+ *
+ * If `config.cache` is `true` and `config` has a `name` or `filename` property, Eta will cache the template on the first render and use the cached template for all subsequent renders.
+ *
+ * @param template Template string or template function
+ * @param data Data to render the template with
+ * @param config Optional config options
+ */
+export default function render(
+    template: string | TemplateFunction,
+    data: object,
+    config?: PartialConfig
+): string;
+
+/**
+ * Render a template
+ *
+ * If `template` is a string, Eta will compile it to a function and then call it with the provided data.
+ * If `template` is a template function, Eta will call it with the provided data.
+ *
+ * If `config.async` is `false`, Eta will return the rendered template.
+ *
+ * If `config.async` is `true` and there's a callback function, Eta will call the callback with `(err, renderedTemplate)`.
+ * If `config.async` is `true` and there's not a callback function, Eta will return a Promise that resolves to the rendered template.
+ *
+ * If `config.cache` is `true` and `config` has a `name` or `filename` property, Eta will cache the template on the first render and use the cached template for all subsequent renders.
+ *
+ * @param template Template string or template function
+ * @param data Data to render the template with
+ * @param config Optional config options
+ * @param cb Callback function
+ */
+export default function render(
+    template: string | TemplateFunction,
+    data: object,
+    config?: PartialConfig,
+    cb?: CallbackFn
+): string | Promise<string> | void;
 
 export default function render(
   template: string | TemplateFunction,


### PR DESCRIPTION
Hey, I really like eta and I have been using it for a few projects already. I would love to contribute to this project. ❤

As already explained in [this issue](https://github.com/eta-dev/eta/issues/189), the types of the render functions can be improved by overloading them. There are essentially three branches and every branch defines their respective return type:

```ts
export default function render(
    template: string | TemplateFunction,
    data: object,
    config?: PartialConfig,
    cb?: CallbackFn
): string | Promise<string> | void {
    if (options.async) {
        if (cb) {
            // user provides callback function
            // return type is void
        } else {
            // user sets async option
            // return type is Promise<string>
        }
    } else {
        // return type is string
    }
}
```

The idea would be to define one function overload per return type so that the function can be consumed easily, without the need of any type assertion. The implementation signature is provided as well in order to prevent breaking changes.

I appreciate any feedback, ideas and suggestions.

This PR resolves https://github.com/eta-dev/eta/issues/189.