### PR TITLE
Nit: change eslint file type

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: ["eta-dev"]
-}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["eta-dev"]
+}


### PR DESCRIPTION
`.eslintrc.cjs` was causing the following eslint error:

> Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser. The extension for the file (.cjs) is non-standard. You should add "parserOptions.extraFileExtensions" to your config.

Since Eta doesn't use CJS internally, instead of doing that, I simply changed the config type to `.json`, which I prefer for configs like this one.