### PR TITLE
Fix outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,21 +13,19 @@
     "typescript types"
   ],
   "homepage": "https://eta.js.org",
-  "type": "module",
+  "type": "commonjs",
   "main": "./dist/eta.umd.js",
-  "module": "./dist/eta.module.js",
   "umd:main": "./dist/eta.umd.js",
   "unpkg": "./dist/browser.min.umd.js",
+  "module": "./dist/eta.module.mjs",
   "types": "./dist/types/eta.d.ts",
   "source": "src/index.ts",
   "exports": {
-    ".": {
-      "types": "./dist/types/eta.d.ts",
-      "browser": "./dist/browser.min.umd.js",
-      "require": "./dist/eta.umd.js",
-      "import": "./dist/eta.module.js",
-      "default": "./dist/eta.umd.js"
-    }
+    "types": "./dist/types/eta.d.ts",
+    "import": "./dist/eta.module.mjs",
+    "require": "./dist/eta.umd.js",
+    "default": "./dist/eta.umd.js",
+    "browser": "./dist/browser.min.umd.js"
   },
   "sideEffects": false,
   "files": [

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "source": "src/index.ts",
   "exports": {
     "types": "./dist/types/eta.d.ts",
-    "import": "./dist/eta.module.mjs",
+    "browser": "./dist/browser.min.umd.js",
     "require": "./dist/eta.umd.js",
-    "default": "./dist/eta.umd.js",
-    "browser": "./dist/browser.min.umd.js"
+    "import": "./dist/eta.module.mjs",
+    "default": "./dist/eta.umd.js"
   },
   "sideEffects": false,
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist",
-    "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "esModuleInterop": true


### PR DESCRIPTION
Closes #210

`--format esm,umd` only spits .js files, which breaks CJS imports because the UMD build uses `require` while package.json sets `type: module`. So if we don't want to generate any cjs, we ought to set the type to commonjs and then generate umd and esm/mjs builds.