### PR TITLE
fix: export EtaConfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,4 +16,4 @@ export { default as compile } from "./compile.js";
 export { default as parse } from "./parse.js";
 export { default as render, renderAsync } from "./render.js";
 export { templates } from "./containers.js";
-export { config, config as defaultConfig, getConfig, configure } from "./config.js";
+export { config, config as defaultConfig, getConfig, configure,  EtaConfig } from "./config.js";


### PR DESCRIPTION
I am working on a mail module with Eta and require the `EtaConfig` type. Using `typeof config` was working but since there is a interface as well, it would look better