### PR TITLE
fix: add support for Bun

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "source": "src/index.ts",
   "exports": {
     "types": "./dist/types/index.d.ts",
+    "import": "./dist/eta.module.mjs",
     "browser": "./dist/browser.umd.js",
     "require": "./dist/eta.umd.js",
-    "import": "./dist/eta.module.mjs",
     "default": "./dist/eta.umd.js"
   },
   "sideEffects": false,


### PR DESCRIPTION
Ref: #181 

Minimum test file:

```js
// test.js
import { Eta } from 'eta'
const eta = new Eta({ views: 'views' })
console.log(eta.render('index'))
```

```html
// views/index.eta
hello
```

When running with Node `node test.js`

```
hello
```


When running with Bun `bun run test.js`

```
2 |         var r = [null];
43 |         r.push.apply(r, e);
44 |         var a = new (Function.bind.apply(t, r));
45 |         return n && i(a, n.prototype), a;
46 | 
47 |       }, a.apply(null, arguments);
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     ^
Eta Error: Failed to get template 'index'
      at a (/Users/muan/Code/testz/node_modules/eta/dist/browser.umd.js:1:1170)
      at n (/Users/muan/Code/testz/node_modules/eta/dist/browser.umd.js:1:1523)
      at new e (/Users/muan/Code/testz/node_modules/eta/dist/browser.umd.js:1:2051)
      at F (/Users/muan/Code/testz/node_modules/eta/dist/browser.umd.js:1:7263)
      at O (/Users/muan/Code/testz/node_modules/eta/dist/browser.umd.js:1:7464)
      at /Users/muan/Code/testz/test.js:3:12
```

Note the `/dist/browser.umd.js`. This is due to [how `bun` resolves files](https://bun.sh/docs/runtime/modules#:~:text=Bun%20respects%20subpath%20%22exports%22%20and%20%22imports%22.%20Specifying%20any%20subpath%20in%20the%20%22exports%22%20map%20will%20prevent%20other%20subpaths%20from%20being%20importable.). It's simply by the order of `exports` keys and it's only if `exports` does not exist does it fallback to `module`.

I can't seem to track down a relevant issue in Bun so this is the best I can come up with for now. 🤷🏻‍♀️ 

With this fix direct applied inside of `node_modules/eta`, the template file resolution is fixed.