### PR TITLE
feat: expose error type

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,4 +1,4 @@
-import { EtaError } from "./err.ts";
+import { EtaParseError } from "./err.ts";
 
 /* TYPES */
 import type { Eta } from "./core.ts";
@@ -33,7 +33,7 @@ export function compile(this: Eta, str: string, options?: Partial<Options>): Tem
     ) as TemplateFunction; // eslint-disable-line no-new-func
   } catch (e) {
     if (e instanceof SyntaxError) {
-      throw new EtaError(
+      throw new EtaParseError(
         "Bad template syntax\n\n" +
           e.message +
           "\n" +

--- a/src/err.ts
+++ b/src/err.ts
@@ -5,28 +5,28 @@ export class EtaError extends Error {
   }
 }
 
-export class EtaParseError extends Error {
+export class EtaParseError extends EtaError {
   constructor(message: string) {
     super(message);
     this.name = "EtaParser Error";
   }
 }
 
-export class EtaRuntimeErr extends Error {
+export class EtaRuntimeError extends EtaError {
   constructor(message: string) {
     super(message);
     this.name = "EtaRuntime Error";
   }
 }
 
-export class EtaFileResolutionError extends Error {
+export class EtaFileResolutionError extends EtaError {
   constructor(message: string) {
     super(message);
     this.name = "EtaFileResolution Error";
   }
 }
 
-export class EtaNameResolutionError extends Error {
+export class EtaNameResolutionError extends EtaError {
   constructor(message: string) {
     super(message);
     this.name = "EtaNameResolution Error";
@@ -75,7 +75,7 @@ export function RuntimeErr(originalError: Error, str: string, lineNo: number, pa
 
   const header = filename ? filename + ":" + lineNo + "\n" : "line " + lineNo + "\n";
 
-  const err = new EtaRuntimeErr(header + context + "\n\n" + originalError.message);
+  const err = new EtaRuntimeError(header + context + "\n\n" + originalError.message);
 
   err.name = originalError.name; // the original name (e.g. ReferenceError) may be useful
 

--- a/src/err.ts
+++ b/src/err.ts
@@ -5,11 +5,18 @@ export class EtaError extends Error {
   }
 }
 
+export class EtaParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EtaParser Error";
+  }
+}
+
 /**
  * Throws an EtaError with a nicely formatted error and message showing where in the template the error occurred.
  */
 
-export function ParseErr(message: string, str: string, indx: number): void {
+export function ParseErr(message: string, str: string, indx: number): never {
   const whitespace = str.slice(0, indx).split(/\n/);
 
   const lineNo = whitespace.length;
@@ -26,7 +33,7 @@ export function ParseErr(message: string, str: string, indx: number): void {
     "  " +
     Array(colNo).join(" ") +
     "^";
-  throw new EtaError(message);
+  throw new EtaParseError(message);
 }
 
 export function RuntimeErr(originalError: Error, str: string, lineNo: number, path: string): void {

--- a/src/err.ts
+++ b/src/err.ts
@@ -12,6 +12,13 @@ export class EtaParseError extends Error {
   }
 }
 
+export class EtaRuntimeErr extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EtaRuntime Error";
+  }
+}
+
 /**
  * Throws an EtaError with a nicely formatted error and message showing where in the template the error occurred.
  */
@@ -36,7 +43,7 @@ export function ParseErr(message: string, str: string, indx: number): never {
   throw new EtaParseError(message);
 }
 
-export function RuntimeErr(originalError: Error, str: string, lineNo: number, path: string): void {
+export function RuntimeErr(originalError: Error, str: string, lineNo: number, path: string): never {
   // code gratefully taken from https://github.com/mde/ejs and adapted
 
   const lines = str.split("\n");
@@ -54,7 +61,7 @@ export function RuntimeErr(originalError: Error, str: string, lineNo: number, pa
 
   const header = filename ? filename + ":" + lineNo + "\n" : "line " + lineNo + "\n";
 
-  const err = new EtaError(header + context + "\n\n" + originalError.message);
+  const err = new EtaRuntimeErr(header + context + "\n\n" + originalError.message);
 
   err.name = originalError.name; // the original name (e.g. ReferenceError) may be useful
 

--- a/src/err.ts
+++ b/src/err.ts
@@ -19,6 +19,13 @@ export class EtaRuntimeErr extends Error {
   }
 }
 
+export class EtaFileResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EtaFileResolution Error";
+  }
+}
+
 /**
  * Throws an EtaError with a nicely formatted error and message showing where in the template the error occurred.
  */

--- a/src/err.ts
+++ b/src/err.ts
@@ -26,6 +26,13 @@ export class EtaFileResolutionError extends Error {
   }
 }
 
+export class EtaNameResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EtaNameResolution Error";
+  }
+}
+
 /**
  * Throws an EtaError with a nicely formatted error and message showing where in the template the error occurred.
  */

--- a/src/file-handling.ts
+++ b/src/file-handling.ts
@@ -1,4 +1,4 @@
-import { EtaError, EtaFileResolutionError } from "./err.ts";
+import { EtaFileResolutionError } from "./err.ts";
 
 import * as path from "node:path";
 
@@ -36,7 +36,7 @@ export function resolvePath(
   const views = this.config.views;
 
   if (!views) {
-    throw new EtaError("Views directory is not defined");
+    throw new EtaFileResolutionError("Views directory is not defined");
   }
 
   const baseFilePath = options && options.filepath;
@@ -80,7 +80,7 @@ export function resolvePath(
 
     return resolvedFilePath;
   } else {
-    throw new EtaError(`Template '${templatePath}' is not in the views directory`);
+    throw new EtaFileResolutionError(`Template '${templatePath}' is not in the views directory`);
   }
 }
 

--- a/src/file-handling.ts
+++ b/src/file-handling.ts
@@ -1,4 +1,4 @@
-import { EtaError } from "./err.ts";
+import { EtaError, EtaFileResolutionError } from "./err.ts";
 
 import * as path from "node:path";
 
@@ -17,7 +17,7 @@ export function readFile(this: EtaCore, path: string): string {
     // eslint-disable-line @typescript-eslint/no-explicit-any
   } catch (err: any) {
     if (err?.code === "ENOENT") {
-      throw new EtaError(`Could not find template: ${path}`);
+      throw new EtaFileResolutionError(`Could not find template: ${path}`);
     } else {
       throw err;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 import { Eta as EtaCore } from "./core.ts";
 import { readFile, resolvePath } from "./file-handling.ts";
-export { EtaParseError, EtaRuntimeErr, EtaFileResolutionError } from "./err.ts";
+export {
+  EtaParseError,
+  EtaRuntimeErr,
+  EtaFileResolutionError,
+  EtaNameResolutionError,
+} from "./err.ts";
 
 export class Eta extends EtaCore {
   readFile = readFile;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Eta as EtaCore } from "./core.ts";
 import { readFile, resolvePath } from "./file-handling.ts";
-export { EtaParseError } from "./err.ts";
+export { EtaParseError, EtaRuntimeErr } from "./err.ts";
 
 export class Eta extends EtaCore {
   readFile = readFile;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Eta as EtaCore } from "./core.ts";
 import { readFile, resolvePath } from "./file-handling.ts";
+export { EtaParseError } from "./err.ts";
 
 export class Eta extends EtaCore {
   readFile = readFile;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Eta as EtaCore } from "./core.ts";
 import { readFile, resolvePath } from "./file-handling.ts";
-export { EtaParseError, EtaRuntimeErr } from "./err.ts";
+export { EtaParseError, EtaRuntimeErr, EtaFileResolutionError } from "./err.ts";
 
 export class Eta extends EtaCore {
   readFile = readFile;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import { Eta as EtaCore } from "./core.ts";
 import { readFile, resolvePath } from "./file-handling.ts";
 export {
+  EtaError,
   EtaParseError,
-  EtaRuntimeErr,
+  EtaRuntimeError,
   EtaFileResolutionError,
   EtaNameResolutionError,
 } from "./err.ts";

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,4 +1,4 @@
-import { EtaError } from "./err.ts";
+import { EtaNameResolutionError } from "./err.ts";
 
 /* TYPES */
 import type { Options } from "./config.ts";
@@ -31,7 +31,7 @@ function handleCache(this: Eta, template: string, options: Partial<Options>): Te
     if (cachedTemplate) {
       return cachedTemplate;
     } else {
-      throw new EtaError("Failed to get template '" + template + "'");
+      throw new EtaNameResolutionError("Failed to get template '" + template + "'");
     }
   }
 }

--- a/test/err.spec.ts
+++ b/test/err.spec.ts
@@ -1,7 +1,7 @@
 /* global it, expect, describe */
 
 import path from "path";
-import { Eta, EtaParseError, EtaRuntimeErr } from "../src/index";
+import { Eta, EtaParseError, EtaRuntimeErr, EtaFileResolutionError } from "../src/index";
 
 describe("ParseErr", () => {
   const eta = new Eta();
@@ -52,6 +52,24 @@ describe("RuntimeErr", () => {
     3| Lorem Ipsum
 
 undefinedVariable is not defined`);
+    }
+  });
+});
+
+describe("EtaFileResolutionError", () => {
+  const eta = new Eta({ debug: true, views: path.join(__dirname, "templates") });
+
+  const errorFilepath = path.join(__dirname, "templates/not-existing-template.eta");
+
+  it("error throws correctly", () => {
+    try {
+      eta.render("./not-existing-template", {});
+    } catch (ex) {
+      expect(ex).toBeInstanceOf(EtaFileResolutionError);
+      expect((ex as EtaFileResolutionError).name).toBe("EtaFileResolution Error");
+      expect((ex as EtaFileResolutionError).message).toBe(
+        `Could not find template: ${errorFilepath}`
+      );
     }
   });
 });

--- a/test/err.spec.ts
+++ b/test/err.spec.ts
@@ -1,7 +1,13 @@
 /* global it, expect, describe */
 
 import path from "path";
-import { Eta, EtaParseError, EtaRuntimeErr, EtaFileResolutionError } from "../src/index";
+import {
+  Eta,
+  EtaParseError,
+  EtaRuntimeErr,
+  EtaFileResolutionError,
+  EtaNameResolutionError,
+} from "../src/index";
 
 describe("ParseErr", () => {
   const eta = new Eta();
@@ -103,6 +109,22 @@ describe("EtaFileResolutionError", () => {
       expect((ex as EtaFileResolutionError).message).toBe(
         `Template '${filePath}' is not in the views directory`
       );
+    }
+  });
+});
+
+describe("EtaNameResolutionError", () => {
+  const eta = new Eta({ debug: true, views: path.join(__dirname, "templates") });
+
+  it("error throws correctly", () => {
+    const template = "@not-existing-tp";
+
+    try {
+      eta.render(template, {});
+    } catch (ex) {
+      expect(ex).toBeInstanceOf(EtaNameResolutionError);
+      expect((ex as EtaNameResolutionError).name).toBe("EtaNameResolution Error");
+      expect((ex as EtaNameResolutionError).message).toBe(`Failed to get template '${template}'`);
     }
   });
 });

--- a/test/err.spec.ts
+++ b/test/err.spec.ts
@@ -3,8 +3,9 @@
 import path from "path";
 import {
   Eta,
+  EtaError,
   EtaParseError,
-  EtaRuntimeErr,
+  EtaRuntimeError,
   EtaFileResolutionError,
   EtaNameResolutionError,
 } from "../src/index";
@@ -16,6 +17,7 @@ describe("ParseErr", () => {
     try {
       eta.renderString("template <%", {});
     } catch (ex) {
+      expect(ex).toBeInstanceOf(EtaError);
       expect(ex).toBeInstanceOf(EtaParseError);
       expect((ex as EtaParseError).name).toBe("EtaParser Error");
       expect((ex as EtaParseError).message).toBe(`unclosed tag at line 1 col 10:
@@ -30,6 +32,7 @@ describe("ParseErr", () => {
     try {
       eta.compile("template <%");
     } catch (ex) {
+      expect(ex).toBeInstanceOf(EtaError);
       expect(ex).toBeInstanceOf(EtaParseError);
       expect((ex as EtaParseError).name).toBe("EtaParser Error");
       expect((ex as EtaParseError).message).toBe(`unclosed tag at line 1 col 10:
@@ -50,9 +53,10 @@ describe("RuntimeErr", () => {
     try {
       eta.render("./runtime-error", {});
     } catch (ex) {
-      expect(ex).toBeInstanceOf(EtaRuntimeErr);
-      expect((ex as EtaRuntimeErr).name).toBe("ReferenceError");
-      expect((ex as EtaRuntimeErr).message).toBe(`${errorFilepath}:2
+      expect(ex).toBeInstanceOf(EtaError);
+      expect(ex).toBeInstanceOf(EtaRuntimeError);
+      expect((ex as EtaRuntimeError).name).toBe("ReferenceError");
+      expect((ex as EtaRuntimeError).message).toBe(`${errorFilepath}:2
     1| 
  >> 2| <%= undefinedVariable %>
     3| Lorem Ipsum
@@ -70,6 +74,7 @@ describe("EtaFileResolutionError", () => {
     try {
       eta.render("./not-existing-template", {});
     } catch (ex) {
+      expect(ex).toBeInstanceOf(EtaError);
       expect(ex).toBeInstanceOf(EtaFileResolutionError);
       expect((ex as EtaFileResolutionError).name).toBe("EtaFileResolution Error");
       expect((ex as EtaFileResolutionError).message).toBe(

--- a/test/err.spec.ts
+++ b/test/err.spec.ts
@@ -57,11 +57,10 @@ undefinedVariable is not defined`);
 });
 
 describe("EtaFileResolutionError", () => {
-  const eta = new Eta({ debug: true, views: path.join(__dirname, "templates") });
+  it("error throws correctly when template does not exist", () => {
+    const eta = new Eta({ debug: true, views: path.join(__dirname, "templates") });
+    const errorFilepath = path.join(__dirname, "templates/not-existing-template.eta");
 
-  const errorFilepath = path.join(__dirname, "templates/not-existing-template.eta");
-
-  it("error throws correctly", () => {
     try {
       eta.render("./not-existing-template", {});
     } catch (ex) {
@@ -69,6 +68,40 @@ describe("EtaFileResolutionError", () => {
       expect((ex as EtaFileResolutionError).name).toBe("EtaFileResolution Error");
       expect((ex as EtaFileResolutionError).message).toBe(
         `Could not find template: ${errorFilepath}`
+      );
+    }
+  });
+
+  it("error throws correctly when views options is missing", async () => {
+    const eta = new Eta({ debug: true });
+    try {
+      eta.render("Hi", {});
+    } catch (ex) {
+      expect(ex).toBeInstanceOf(EtaFileResolutionError);
+      expect((ex as EtaFileResolutionError).name).toBe("EtaFileResolution Error");
+      expect((ex as EtaFileResolutionError).message).toBe("Views directory is not defined");
+    }
+
+    try {
+      await eta.renderAsync("Hi", {});
+    } catch (ex) {
+      expect(ex).toBeInstanceOf(EtaFileResolutionError);
+      expect((ex as EtaFileResolutionError).name).toBe("EtaFileResolution Error");
+      expect((ex as EtaFileResolutionError).message).toBe("Views directory is not defined");
+    }
+  });
+
+  it("error throws correctly when template in not in th view directory", () => {
+    const eta = new Eta({ debug: true, views: path.join(__dirname, "templates") });
+
+    const filePath = "../../../simple.eta";
+    try {
+      eta.render(filePath, {});
+    } catch (ex) {
+      expect(ex).toBeInstanceOf(EtaFileResolutionError);
+      expect((ex as EtaFileResolutionError).name).toBe("EtaFileResolution Error");
+      expect((ex as EtaFileResolutionError).message).toBe(
+        `Template '${filePath}' is not in the views directory`
       );
     }
   });

--- a/test/err.spec.ts
+++ b/test/err.spec.ts
@@ -6,9 +6,23 @@ import { Eta, EtaParseError, EtaRuntimeErr } from "../src/index";
 describe("ParseErr", () => {
   const eta = new Eta();
 
-  it("error while parsing", () => {
+  it("error while parsing - renderString", () => {
     try {
       eta.renderString("template <%", {});
+    } catch (ex) {
+      expect(ex).toBeInstanceOf(EtaParseError);
+      expect((ex as EtaParseError).name).toBe("EtaParser Error");
+      expect((ex as EtaParseError).message).toBe(`unclosed tag at line 1 col 10:
+
+  template <%
+           ^`);
+      expect(ex instanceof Error).toBe(true);
+    }
+  });
+
+  it("error while parsing - compile", () => {
+    try {
+      eta.compile("template <%");
     } catch (ex) {
       expect(ex).toBeInstanceOf(EtaParseError);
       expect((ex as EtaParseError).name).toBe("EtaParser Error");

--- a/test/err.spec.ts
+++ b/test/err.spec.ts
@@ -1,7 +1,7 @@
 /* global it, expect, describe */
 
 import path from "path";
-import { Eta } from "../src/index";
+import { Eta, EtaParseError } from "../src/index";
 
 describe("ParseErr", () => {
   const eta = new Eta();
@@ -10,8 +10,9 @@ describe("ParseErr", () => {
     try {
       eta.renderString("template <%", {});
     } catch (ex) {
-      expect((ex as Error).name).toBe("Eta Error");
-      expect((ex as Error).message).toBe(`unclosed tag at line 1 col 10:
+      expect(ex).toBeInstanceOf(EtaParseError);
+      expect((ex as EtaParseError).name).toBe("EtaParser Error");
+      expect((ex as EtaParseError).message).toBe(`unclosed tag at line 1 col 10:
 
   template <%
            ^`);

--- a/test/err.spec.ts
+++ b/test/err.spec.ts
@@ -1,7 +1,7 @@
 /* global it, expect, describe */
 
 import path from "path";
-import { Eta, EtaParseError } from "../src/index";
+import { Eta, EtaParseError, EtaRuntimeErr } from "../src/index";
 
 describe("ParseErr", () => {
   const eta = new Eta();
@@ -30,8 +30,9 @@ describe("RuntimeErr", () => {
     try {
       eta.render("./runtime-error", {});
     } catch (ex) {
-      expect((ex as Error).name).toBe("ReferenceError");
-      expect((ex as Error).message).toBe(`${errorFilepath}:2
+      expect(ex).toBeInstanceOf(EtaRuntimeErr);
+      expect((ex as EtaRuntimeErr).name).toBe("ReferenceError");
+      expect((ex as EtaRuntimeErr).message).toBe(`${errorFilepath}:2
     1| 
  >> 2| <%= undefinedVariable %>
     3| Lorem Ipsum


### PR DESCRIPTION
I tried to export EtaError types introducing new types like @nebrelbug did in [THIS](https://github.com/eta-dev/eta/issues/243) issue.

Some point about he PR:
- I put an EtaXXXError instead EtaError in all point. So at the and I asked myself "Is now useless EtaError type? Can I remove it"
- I added a test for each error interface. I tried to `throw` starting from top-level api. For example using `.render()` even if the exception is inside `.readFile()`
- I added `never` as return type since for me a function that throw 100% of times an error equals to a function that never run an error (token from TS docs)

I don't know if this PR follow exactly the structure described here:
https://github.com/eta-dev/eta/issues/243#issuecomment-1646243319

But probably this PR can be a starting point and I'm happy to change some part after review