### PR TITLE
feat: adjust render types to be generic

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -36,10 +36,10 @@ function handleCache(this: Eta, template: string, options: Partial<Options>): Te
   }
 }
 
-export function render(
+export function render<T extends object>(
   this: Eta,
   template: string | TemplateFunction, // template name or template function
-  data: object,
+  data: T,
   meta?: { filepath: string }
 ): string {
   let templateFn: TemplateFunction;
@@ -60,10 +60,10 @@ export function render(
   return res;
 }
 
-export function renderAsync(
+export function renderAsync<T extends object>(
   this: Eta,
   template: string | TemplateFunction, // template name or template function
-  data: object,
+  data: T,
   meta?: { filepath: string }
 ): Promise<string> {
   let templateFn: TemplateFunction;
@@ -85,13 +85,13 @@ export function renderAsync(
   return Promise.resolve(res);
 }
 
-export function renderString(this: Eta, template: string, data: object): string {
+export function renderString<T extends object>(this: Eta, template: string, data: T): string {
   const templateFn = this.compile(template, { async: false });
 
   return render.call(this, templateFn, data);
 }
 
-export function renderStringAsync(this: Eta, template: string, data: object): Promise<string> {
+export function renderStringAsync<T extends object>(this: Eta, template: string, data: T): Promise<string> {
   const templateFn = this.compile(template, { async: true });
 
   return renderAsync.call(this, templateFn, data);

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 
 import { Eta } from "../src/index";
 
+interface SimpleEtaTemplate {
+  name: string;
+}
+
 describe("basic functionality", () => {
   const eta = new Eta();
 
@@ -139,7 +143,7 @@ describe("file rendering", () => {
   const eta = new Eta({ views: path.join(__dirname, "templates") });
 
   it("renders template file properly", () => {
-    const res = eta.render("simple.eta", { name: "friend" });
+    const res = eta.render<SimpleEtaTemplate>("simple.eta", { name: "friend" });
 
     expect(res).toEqual("Hi friend");
   });


### PR DESCRIPTION
## What & Why

Adjust the types of `render*` functions to include a generic for `data`. This will allow developers to type their render functions and more safely guard their templates 💃

## Proof

Not adding a type falls back to `object`

![no-types-work](https://github.com/eta-dev/eta/assets/17285719/2ab6d1e7-f412-4fa8-b8c2-d1325bbddc71)

Adding a type allows you to enforce your will 🤖 

![types-work](https://github.com/eta-dev/eta/assets/17285719/663340d1-fcf5-4f92-ab10-e90fefcc6fd7)
