### PR TITLE
add releases to JSR

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,12 @@
+{
+  "name": "@eta-dev/eta",
+  "version": "3.4.0",
+  "exports": "./src/index.ts",
+  "publish": {
+    "include": [
+      "LICENSE",
+      "README.md",
+      "src/**/*.ts"
+    ]
+  }
+}

--- a/jsr.release.js
+++ b/jsr.release.js
@@ -1,0 +1,4 @@
+require('node:fs').writeFileSync('jsr.json', JSON.stringify({
+  ...require('./jsr.json'),
+  "version": require('./package.json').version,
+}, null, 2) + '\n');

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "lint": "eslint src/*.ts test/*.spec.ts --ext .js,.ts",
     "prebuild": "rimraf dist",
     "release": "npm run build && np",
+    "postversion": "node ./jsr.release.js",
     "size": "size-limit",
     "start": "microbundle watch",
     "test": "jest --coverage && npm run size",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "format": "prettier --write '{src,test}/**/**.ts'",
     "lint": "eslint src/*.ts test/*.spec.ts --ext .js,.ts",
     "prebuild": "rimraf dist",
-    "release": "npm run build && np",
+    "release": "npm run build && np && npx jsr publish",
     "postversion": "node ./jsr.release.js",
     "size": "size-limit",
     "start": "microbundle watch",

--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -74,7 +74,7 @@ return __eta.res;
  * ```
  */
 
-export function compileBody(this: Eta, buff: Array<AstObject>) {
+export function compileBody(this: Eta, buff: Array<AstObject>): string {
   const config = this.config;
 
   let i = 0;

--- a/src/core.ts
+++ b/src/core.ts
@@ -34,8 +34,8 @@ export class Eta {
   renderStringAsync = renderStringAsync;
 
   filepathCache: Record<string, string> = {};
-  templatesSync = new Cacher<TemplateFunction>({});
-  templatesAsync = new Cacher<TemplateFunction>({});
+  templatesSync: Cacher<TemplateFunction> = new Cacher<TemplateFunction>({});
+  templatesAsync: Cacher<TemplateFunction> = new Cacher<TemplateFunction>({});
 
   // resolvePath takes a relative path from the "views" directory
   resolvePath: null | ((this: Eta, template: string, options?: Partial<Options>) => string) = null;
@@ -47,7 +47,7 @@ export class Eta {
     this.config = { ...this.config, ...customConfig };
   }
 
-  withConfig(customConfig: Partial<EtaConfig>) {
+  withConfig(customConfig: Partial<EtaConfig>): this & { config: EtaConfig }{
     return { ...this, config: { ...this.config, ...customConfig } };
   }
 


### PR DESCRIPTION
Adding a step in the release pipeline to update a `jsr.json` when creating a new release version, and then release to JSR if npm release succeeded.

Just tried shortening the update scripts, I could just put it inline in the scripts if you prefer:
```json
{
    "postversion": "node -e \"let r=require;r('fs').writeFileSync('jsr.json', JSON.stringify({...r('./jsr.json'),version: r('./package.json').version},null, 2)+'\\n');\"",
}
```

The only other step to be able to release to JSR would be registering the package scope/name and auth on the first upload.

closes #290 