### PR TITLE
fix: bundlers not using the `browser` export

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "source": "src/index.ts",
   "exports": {
     "types": "./dist/types/index.d.ts",
-    "import": "./dist/eta.module.mjs",
     "browser": "./dist/browser.umd.js",
+    "import": "./dist/eta.module.mjs",
     "require": "./dist/eta.umd.js",
     "default": "./dist/eta.umd.js"
   },


### PR DESCRIPTION
Bundlers use _conditions_ to decide which file to import. The logic, [explained by esbuild](https://esbuild.github.io/api/#how-conditions-work) emphasizes it would read the `exports` field *in-order* and try matching it to any of the conditions.

When bundling for `browser`, eslint will end up adding `default` and `import` to the list of _conditions_. When iterating `eta`'s `exports` list, it ended up catching `import` instead of `browser`. With this change, it will first catch `browser`.

How to test?
---
Create a new file named `index.mjs` with the following content:

```javascript
import { Eta } from 'eta';

const eta = new Eta();
```

Install `esbuild` and `eta`:
```sh
npm i --save-dev esbuild eta
```

Try to bundle the file:
```sh
npx esbuild index.mjs --bundle --conditions=browser
```

With the current published version (3.4.1) it will emit an error:
```
✘ [ERROR] Could not resolve "node:path"

    node_modules/eta/dist/eta.module.mjs:1:22:
      1 │ import * as path from 'node:path';
        ╵                       ~~~~~~~~~~~

  The package "node:path" wasn't found on the file system but is built into node. Are you trying to
  bundle for node? You can use "--platform=node" to do that, which will remove this error.
```

When trying with this branch's build, it passes successfully.

resolves eta-dev/eta#283