### PR TITLE
feat: expose resolvePath to templates

### DIFF
--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -26,6 +26,7 @@ export function compileToString(
   let res = `${config.functionHeader}
 let include = (template, data) => this.render(template, data, options);
 let includeAsync = (template, data) => this.renderAsync(template, data, options);
+let resolvePath = (template) => this.resolvePath(template, options);
 
 let __eta = {res: "", e: this.config.escapeFunction, f: this.config.filterFunction${
     config.debug


### PR DESCRIPTION
This PR adds ```resolvePath``` to transform relative paths into absolute ones.
A use case for this is dynamic import, e.g.:
```
<% let utils = await import (resolvePath("./include/utils.mjs")) %>
```
The lack of this feature can be worked around by exposing ```Eta.resolvePath``` via ```it```. However, if used in a _partial_, the base path used to resolve the relative path would always be the directory of the including (root) template, which could lead to confusion.