### PR TITLE
Add error.cause to RuntimeErr

### DIFF
--- a/src/err.ts
+++ b/src/err.ts
@@ -86,6 +86,7 @@ export function RuntimeErr(
   );
 
   err.name = originalError.name; // the original name (e.g. ReferenceError) may be useful
+  err.cause = originalError;
 
   throw err;
 }


### PR DESCRIPTION
Adding `error.cause` can help developers locate the origins of an exception if it is happening in their own code that is called by the template at runtime. Now this stack is available.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause