### PR TITLE
chore: Add Vite integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ To render Eta templates in [Koa](https://koajs.com) web framework: [@cedx/koa-et
 
 </details>
 
+<details>
+  <summary>
+    <b>Vite</b>
+  </summary>
+
+To use Eta templates in your Vite project: [@rinoshiyo/vite-plugin-eta](https://github.com/rinoshiyo/vite-plugin-eta)
+
+</details>
+
 <br />
 
 ## Projects using `eta`


### PR DESCRIPTION
Hello!

I've created a Vite plugin for Eta, which allows users to easily integrate Eta templates into their Vite projects.
Could you please consider adding this integration to the README under the "Integrations" section?

Repository: https://github.com/rinoshiyo/vite-plugin-eta
npm Package: https://www.npmjs.com/package/@rinoshiyo/vite-plugin-eta

Thanks!