### PR TITLE
Add require field for core module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
       "require": "./dist/index.cjs"
     },
     "./core": {
+      "require": "./dist/core.js",
       "import": "./dist/core.js",
       "types": "./dist/core.d.ts"
     },


### PR DESCRIPTION
We're using this package transitively through the oidc-provider package, which for some reason is directly using the core.js file, and that file is not being resolved at runtime. Unfortunately the oidc-provider repo has the "issues" tab disabled, so we can't report this bug there. But this patch fixes it anyway.