### PR TITLE
feat: add block and blockAsync template helpers

### DIFF
--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -23,7 +23,7 @@ export function compileToString(
 let include = (__eta_t, __eta_d) => this.render(__eta_t, {...${config.varName}, ...(__eta_d ?? {})}, options);
 let includeAsync = (__eta_t, __eta_d) => this.renderAsync(__eta_t, {...${config.varName}, ...(__eta_d ?? {})}, options);
 
-let __eta = {res: "", e: this.config.escapeFunction, f: this.config.filterFunction${
+let __eta = {res: "", e: this.config.escapeFunction, f: this.config.filterFunction, blocks: {}${
     config.debug
       ? ', line: 1, templateStr: "' +
         str.replace(/\\|"/g, "\\$&").replace(/\r\n|\n|\r/g, "\\n") +
@@ -41,6 +41,8 @@ function layout(path, data) {
 function ${config.outputFunctionName}(s){__eta.res+=s;}
 function capture(fn){const s=__eta.res;__eta.res='';try{fn();return __eta.res}finally{__eta.res=s;}}
 async function captureAsync(fn){const s=__eta.res;__eta.res='';try{await fn();return __eta.res}finally{__eta.res=s;}}
+function block(name,fn){if(__eta.layout){if(fn){__eta.blocks[name]=capture(fn);}return '';}const b=${config.varName}.__blocks||{};if(name in b){return b[name];}return fn?capture(fn):'';}
+async function blockAsync(name,fn){if(__eta.layout){if(fn){__eta.blocks[name]=await captureAsync(fn);}return '';}const b=${config.varName}.__blocks||{};if(name in b){return b[name];}return fn?await captureAsync(fn):'';}
 
 ${compileBody.call(this, buffer)}
 if (__eta.layout) {
@@ -48,7 +50,7 @@ if (__eta.layout) {
     isAsync ? "await includeAsync" : "include"
   } (__eta.layout, {...${
     config.varName
-  }, body: __eta.res, ...__eta.layoutData});
+  }, body: __eta.res, ...__eta.layoutData, __blocks: __eta.blocks});
 }
 ${config.useWith ? "}" : ""}${
   config.debug

--- a/test/compile-string.spec.ts
+++ b/test/compile-string.spec.ts
@@ -17,7 +17,7 @@ describe("Compile to String test", () => {
 let include = (__eta_t, __eta_d) => this.render(__eta_t, {...it, ...(__eta_d ?? {})}, options);
 let includeAsync = (__eta_t, __eta_d) => this.renderAsync(__eta_t, {...it, ...(__eta_d ?? {})}, options);
 
-let __eta = {res: "", e: this.config.escapeFunction, f: this.config.filterFunction};
+let __eta = {res: "", e: this.config.escapeFunction, f: this.config.filterFunction, blocks: {}};
 
 function layout(path, data) {
   __eta.layout = path;
@@ -27,12 +27,14 @@ function layout(path, data) {
 function output(s){__eta.res+=s;}
 function capture(fn){const s=__eta.res;__eta.res='';try{fn();return __eta.res}finally{__eta.res=s;}}
 async function captureAsync(fn){const s=__eta.res;__eta.res='';try{await fn();return __eta.res}finally{__eta.res=s;}}
+function block(name,fn){if(__eta.layout){if(fn){__eta.blocks[name]=capture(fn);}return '';}const b=it.__blocks||{};if(name in b){return b[name];}return fn?capture(fn):'';}
+async function blockAsync(name,fn){if(__eta.layout){if(fn){__eta.blocks[name]=await captureAsync(fn);}return '';}const b=it.__blocks||{};if(name in b){return b[name];}return fn?await captureAsync(fn):'';}
 
 __eta.res+='hi ';
 __eta.res+=__eta.e(it.name);
 
 if (__eta.layout) {
-  __eta.res = include (__eta.layout, {...it, body: __eta.res, ...__eta.layoutData});
+  __eta.res = include (__eta.layout, {...it, body: __eta.res, ...__eta.layoutData, __blocks: __eta.blocks});
 }
 
 return __eta.res;
@@ -45,7 +47,7 @@ return __eta.res;
 let include = (__eta_t, __eta_d) => this.render(__eta_t, {...it, ...(__eta_d ?? {})}, options);
 let includeAsync = (__eta_t, __eta_d) => this.renderAsync(__eta_t, {...it, ...(__eta_d ?? {})}, options);
 
-let __eta = {res: "", e: this.config.escapeFunction, f: this.config.filterFunction};
+let __eta = {res: "", e: this.config.escapeFunction, f: this.config.filterFunction, blocks: {}};
 
 function layout(path, data) {
   __eta.layout = path;
@@ -55,12 +57,14 @@ function layout(path, data) {
 function output(s){__eta.res+=s;}
 function capture(fn){const s=__eta.res;__eta.res='';try{fn();return __eta.res}finally{__eta.res=s;}}
 async function captureAsync(fn){const s=__eta.res;__eta.res='';try{await fn();return __eta.res}finally{__eta.res=s;}}
+function block(name,fn){if(__eta.layout){if(fn){__eta.blocks[name]=capture(fn);}return '';}const b=it.__blocks||{};if(name in b){return b[name];}return fn?capture(fn):'';}
+async function blockAsync(name,fn){if(__eta.layout){if(fn){__eta.blocks[name]=await captureAsync(fn);}return '';}const b=it.__blocks||{};if(name in b){return b[name];}return fn?await captureAsync(fn):'';}
 
 __eta.res+='hi ';
 __eta.res+=it.name;
 
 if (__eta.layout) {
-  __eta.res = include (__eta.layout, {...it, body: __eta.res, ...__eta.layoutData});
+  __eta.res = include (__eta.layout, {...it, body: __eta.res, ...__eta.layoutData, __blocks: __eta.blocks});
 }
 
 return __eta.res;
@@ -75,7 +79,7 @@ return __eta.res;
 let include = (__eta_t, __eta_d) => this.render(__eta_t, {...it, ...(__eta_d ?? {})}, options);
 let includeAsync = (__eta_t, __eta_d) => this.renderAsync(__eta_t, {...it, ...(__eta_d ?? {})}, options);
 
-let __eta = {res: "", e: this.config.escapeFunction, f: this.config.filterFunction};
+let __eta = {res: "", e: this.config.escapeFunction, f: this.config.filterFunction, blocks: {}};
 
 function layout(path, data) {
   __eta.layout = path;
@@ -85,13 +89,15 @@ function layout(path, data) {
 function output(s){__eta.res+=s;}
 function capture(fn){const s=__eta.res;__eta.res='';try{fn();return __eta.res}finally{__eta.res=s;}}
 async function captureAsync(fn){const s=__eta.res;__eta.res='';try{await fn();return __eta.res}finally{__eta.res=s;}}
+function block(name,fn){if(__eta.layout){if(fn){__eta.blocks[name]=capture(fn);}return '';}const b=it.__blocks||{};if(name in b){return b[name];}return fn?capture(fn):'';}
+async function blockAsync(name,fn){if(__eta.layout){if(fn){__eta.blocks[name]=await captureAsync(fn);}return '';}const b=it.__blocks||{};if(name in b){return b[name];}return fn?await captureAsync(fn):'';}
 
 __eta.res+='hi';
 __eta.res+=__eta.e(it.firstname);
 __eta.res+=__eta.e(it.lastname);
 
 if (__eta.layout) {
-  __eta.res = include (__eta.layout, {...it, body: __eta.res, ...__eta.layoutData});
+  __eta.res = include (__eta.layout, {...it, body: __eta.res, ...__eta.layoutData, __blocks: __eta.blocks});
 }
 
 return __eta.res;
@@ -104,7 +110,7 @@ return __eta.res;
 let include = (__eta_t, __eta_d) => this.render(__eta_t, {...it, ...(__eta_d ?? {})}, options);
 let includeAsync = (__eta_t, __eta_d) => this.renderAsync(__eta_t, {...it, ...(__eta_d ?? {})}, options);
 
-let __eta = {res: "", e: this.config.escapeFunction, f: this.config.filterFunction};
+let __eta = {res: "", e: this.config.escapeFunction, f: this.config.filterFunction, blocks: {}};
 
 function layout(path, data) {
   __eta.layout = path;
@@ -114,6 +120,8 @@ function layout(path, data) {
 function output(s){__eta.res+=s;}
 function capture(fn){const s=__eta.res;__eta.res='';try{fn();return __eta.res}finally{__eta.res=s;}}
 async function captureAsync(fn){const s=__eta.res;__eta.res='';try{await fn();return __eta.res}finally{__eta.res=s;}}
+function block(name,fn){if(__eta.layout){if(fn){__eta.blocks[name]=capture(fn);}return '';}const b=it.__blocks||{};if(name in b){return b[name];}return fn?capture(fn):'';}
+async function blockAsync(name,fn){if(__eta.layout){if(fn){__eta.blocks[name]=await captureAsync(fn);}return '';}const b=it.__blocks||{};if(name in b){return b[name];}return fn?await captureAsync(fn):'';}
 
 __eta.res+='Hi\\n';
 console.log("Hope you like Eta!")
@@ -140,7 +148,7 @@ __eta.res+='\\nThis is a partial: ';
 __eta.res+=include("mypartial");
 
 if (__eta.layout) {
-  __eta.res = include (__eta.layout, {...it, body: __eta.res, ...__eta.layoutData});
+  __eta.res = include (__eta.layout, {...it, body: __eta.res, ...__eta.layoutData, __blocks: __eta.blocks});
 }
 
 return __eta.res;

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -396,15 +396,9 @@ describe("block", () => {
   });
 
   it("empty block with no default and no override", () => {
-    eta.loadTemplate(
-      "@block-empty",
-      `[<%~ block('sidebar') %>]<%~ it.body %>`,
-    );
+    eta.loadTemplate("@block-empty", `[<%~ block('sidebar') %>]<%~ it.body %>`);
 
-    const res = eta.renderString(
-      `<% layout("@block-empty") %>main`,
-      {},
-    );
+    const res = eta.renderString(`<% layout("@block-empty") %>main`, {});
 
     expect(res).toEqual("[]main");
   });
@@ -424,10 +418,7 @@ describe("block", () => {
   });
 
   it("block accessing outer scope data", () => {
-    eta.loadTemplate(
-      "@block-data",
-      `<%~ block('title') %>|<%~ it.body %>`,
-    );
+    eta.loadTemplate("@block-data", `<%~ block('title') %>|<%~ it.body %>`);
 
     const res = eta.renderString(
       `<% layout("@block-data") %>body<% block('title', () => { %><%= it.name %><% }) %>`,
@@ -471,10 +462,7 @@ describe("capture", () => {
   const eta = new Eta();
 
   it("captures inline HTML and passes it to an included template", () => {
-    eta.loadTemplate(
-      "@wrapper",
-      `<div id="wrapper"><%~ it.content %></div>`,
-    );
+    eta.loadTemplate("@wrapper", `<div id="wrapper"><%~ it.content %></div>`);
 
     const res = eta.renderString(
       `<%~ include("@wrapper", {content: capture(() => { %><h1>Hello</h1><% })}) %>`,
@@ -530,10 +518,7 @@ describe("capture", () => {
   });
 
   it("works with async rendering", async () => {
-    eta.loadTemplate(
-      "@async-wrapper",
-      `<div><%~ it.content %></div>`,
-    );
+    eta.loadTemplate("@async-wrapper", `<div><%~ it.content %></div>`);
 
     const res = await eta.renderStringAsync(
       `<%~ include("@async-wrapper", {content: capture(() => { %><p>async content</p><% })}) %>`,
@@ -566,10 +551,7 @@ describe("capture", () => {
   });
 
   it("captureAsync works with async content", async () => {
-    eta.loadTemplate(
-      "@async-slot",
-      `<section><%~ it.content %></section>`,
-    );
+    eta.loadTemplate("@async-slot", `<section><%~ it.content %></section>`);
 
     const res = await eta.renderStringAsync(
       `<%~ include("@async-slot", {content: await captureAsync(async () => { %><p><%= await it.getData() %></p><% })}) %>`,

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -364,6 +364,109 @@ describe("forEach loops in included templates", () => {
   });
 });
 
+describe("block", () => {
+  const eta = new Eta();
+
+  it("child overrides layout default", () => {
+    eta.loadTemplate(
+      "@block-layout",
+      `<head><%~ block('styles', () => { %><link href="default.css"><% }) %></head><%~ it.body %>`,
+    );
+
+    const res = eta.renderString(
+      `<% layout("@block-layout") %><p>Body</p><% block('styles', () => { %><link href="page.css"><% }) %>`,
+      {},
+    );
+
+    expect(res).toEqual('<head><link href="page.css"></head><p>Body</p>');
+  });
+
+  it("block with default content when no override", () => {
+    eta.loadTemplate(
+      "@block-default",
+      `<head><%~ block('styles', () => { %><link href="default.css"><% }) %></head><%~ it.body %>`,
+    );
+
+    const res = eta.renderString(
+      `<% layout("@block-default") %><p>Body</p>`,
+      {},
+    );
+
+    expect(res).toEqual('<head><link href="default.css"></head><p>Body</p>');
+  });
+
+  it("empty block with no default and no override", () => {
+    eta.loadTemplate(
+      "@block-empty",
+      `[<%~ block('sidebar') %>]<%~ it.body %>`,
+    );
+
+    const res = eta.renderString(
+      `<% layout("@block-empty") %>main`,
+      {},
+    );
+
+    expect(res).toEqual("[]main");
+  });
+
+  it("multiple blocks in one layout", () => {
+    eta.loadTemplate(
+      "@block-multi",
+      `<head><%~ block('styles') %></head><footer><%~ block('scripts') %></footer><%~ it.body %>`,
+    );
+
+    const res = eta.renderString(
+      `<% layout("@block-multi") %>body<% block('styles', () => { %>S<% }) %><% block('scripts', () => { %>J<% }) %>`,
+      {},
+    );
+
+    expect(res).toEqual("<head>S</head><footer>J</footer>body");
+  });
+
+  it("block accessing outer scope data", () => {
+    eta.loadTemplate(
+      "@block-data",
+      `<%~ block('title') %>|<%~ it.body %>`,
+    );
+
+    const res = eta.renderString(
+      `<% layout("@block-data") %>body<% block('title', () => { %><%= it.name %><% }) %>`,
+      { name: "Ada" },
+    );
+
+    expect(res).toEqual("Ada|body");
+  });
+
+  it("block doesn't leak into it.body", () => {
+    eta.loadTemplate(
+      "@block-noleak",
+      `[<%~ block('extra') %>][<%~ it.body %>]`,
+    );
+
+    const res = eta.renderString(
+      `<% layout("@block-noleak") %>body<% block('extra', () => { %>X<% }) %>`,
+      {},
+    );
+
+    expect(res).toEqual("[X][body]");
+  });
+
+  it("blockAsync with async content", async () => {
+    eta.loadTemplate(
+      "@block-async-layout",
+      `<%~ await blockAsync('content') %>|<%~ it.body %>`,
+      { async: true },
+    );
+
+    const res = await eta.renderStringAsync(
+      `<% layout("@block-async-layout") %>body<% await blockAsync('content', async () => { %><%= await it.getData() %><% }) %>`,
+      { getData: () => Promise.resolve("async-val") },
+    );
+
+    expect(res).toEqual("async-val|body");
+  });
+});
+
 describe("capture", () => {
   const eta = new Eta();
 


### PR DESCRIPTION
## Summary

- Adds `block(name, fn?)` and `blockAsync(name, fn?)` helpers for Nunjucks/Blade-style named blocks in layouts
- Child templates define block overrides; layouts define slots with optional defaults
- Built on top of the `capture`/`captureAsync` primitives from #365 — no new parsing logic

## Usage

**Child template:**
```html
<% layout("@main") %>
<p>Body</p>
<% block('styles', () => { %><link href="page.css"><% }) %>
```

**Layout template:**
```html
<head><%~ block('styles', () => { %><link href="default.css"><% }) %></head>
<%~ it.body %>
```

If the child defines a block, it overrides the layout default. If not, the default runs. If neither provides content, the block renders as an empty string.

## Changes

- `src/compile-string.ts` — add `blocks: {}` to `__eta`, inject `block`/`blockAsync` functions, pass `__blocks` to layout render call
- `test/compile-string.spec.ts` — update 4 compiled output snapshots
- `test/render.spec.ts` — add 7 tests (override, default, empty, multiple blocks, data access, no body leakage, async)

## Test plan

- [x] All 7 new block tests pass
- [x] All 4 compile-string snapshot tests updated and passing
- [x] Full suite (102 tests) green

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)