### PR TITLE
feat: add support for custom tag types

### DIFF
--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -127,7 +127,7 @@ export function compileBody(this: Eta, buff: Array<AstObject>): string {
       } else if (type === "e") {
         // execute
         returnStr += content + "\n";
-      } else if (type in config.customTags) {
+      } else if (Object.hasOwn(config.customTags, type)) {
         returnStr += `__eta.res+=this.config.customTags[${JSON.stringify(type)}](${JSON.stringify(content)},${config.varName});\n`;
       }
     }

--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -99,7 +99,7 @@ export function compileBody(this: Eta, buff: Array<AstObject>): string {
       // we know string exists
       returnStr += "__eta.res+='" + str + "';\n";
     } else {
-      const type = currentBlock.t; // "r", "e", or "i"
+      const type = currentBlock.t; // "r", "e", "i" or custom tag name
       let content = currentBlock.val || "";
 
       if (config.debug) returnStr += "__eta.line=" + currentBlock.lineNo + "\n";
@@ -127,6 +127,10 @@ export function compileBody(this: Eta, buff: Array<AstObject>): string {
       } else if (type === "e") {
         // execute
         returnStr += content + "\n";
+
+      } else if (type in config.customTags) {
+        const customTag = config.customTags[type];
+        returnStr += `__eta.res += this.config.customTags['${type}']('${content}', ${config.varName});\n`;
       }
     }
   }

--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -127,10 +127,8 @@ export function compileBody(this: Eta, buff: Array<AstObject>): string {
       } else if (type === "e") {
         // execute
         returnStr += content + "\n";
-
       } else if (type in config.customTags) {
-        const customTag = config.customTags[type];
-        returnStr += `__eta.res += this.config.customTags['${type}']('${content}', ${config.varName});\n`;
+        returnStr += `__eta.res+=this.config.customTags[${JSON.stringify(type)}](${JSON.stringify(content)},${config.varName});\n`;
       }
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,9 @@ export interface EtaConfig {
   /** Holds cache of resolved filepaths. Set to `false` to disable. */
   cacheFilepaths: boolean;
 
+  /** Object specifying custom tags. Keys are tag prefixes, values are functions which take tag content and return a string. */
+  customTags: Record<string, (content: string, data: unknown) => string>;
+
   /** Whether to pretty-format error messages (introduces runtime penalties) */
   debug: boolean;
 
@@ -89,6 +92,7 @@ const defaultConfig: EtaConfig = {
   autoTrim: [false, "nl"],
   cache: false,
   cacheFilepaths: true,
+  customTags: {},
   debug: false,
   escapeFunction: XMLEscape,
   // default filter function (not used unless enables) just stringifies the input

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -20,6 +20,22 @@ export class Eta {
     } else {
       this.config = { ...defaultConfig };
     }
+
+    const reserved = [
+      this.config.parse.exec,
+      this.config.parse.interpolate,
+      this.config.parse.raw,
+      "-",
+      "_",
+    ];
+
+    for (const prefix of Object.keys(this.config.customTags)) {
+      if (reserved.includes(prefix)) {
+        throw new EtaError(
+          `Custom tag prefix "${prefix}" conflicts with a built-in prefix`,
+        );
+      }
+    }
   }
 
   config: EtaConfig;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -2,10 +2,8 @@ import { ParseErr } from "./err.ts";
 import type { Eta } from "./internal.ts";
 import { trimWS } from "./utils.ts";
 
-export type TagType = "r" | "e" | "i" | "";
-
 export interface TemplateObject {
-  t: TagType;
+  t: string;
   val: string;
   lineNo?: number;
 }
@@ -39,6 +37,8 @@ export function parse(this: Eta, str: string): Array<AstObject> {
   let trimLeftOfNextStr: string | false = false;
   let lastIndex = 0;
   const parseOptions = config.parse;
+
+  const customTagPrefixes = Object.keys(config.customTags)
 
   if (config.plugins) {
     for (let i = 0; i < config.plugins.length; i++) {
@@ -90,6 +90,7 @@ export function parse(this: Eta, str: string): Array<AstObject> {
     parseOptions.exec,
     parseOptions.interpolate,
     parseOptions.raw,
+    ...customTagPrefixes,
   ].reduce((accumulator, prefix) => {
     if (accumulator && prefix) {
       return accumulator + "|" + escapeRegExp(prefix);
@@ -138,14 +139,12 @@ export function parse(this: Eta, str: string): Array<AstObject> {
 
         trimLeftOfNextStr = closeTag[2];
 
-        const currentType: TagType =
-          prefix === parseOptions.exec
-            ? "e"
-            : prefix === parseOptions.raw
-              ? "r"
-              : prefix === parseOptions.interpolate
-                ? "i"
-                : "";
+        let currentType = "";
+        if(prefix === config.parse.exec) currentType = "e";
+        else if(prefix === config.parse.interpolate) currentType = "i";
+        else if(prefix === config.parse.raw) currentType = "r";
+        // custom tags
+        else if(customTagPrefixes.includes(prefix)) currentType = prefix;
 
         currentObj = { t: currentType, val: content };
         break;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -38,7 +38,7 @@ export function parse(this: Eta, str: string): Array<AstObject> {
   let lastIndex = 0;
   const parseOptions = config.parse;
 
-  const customTagPrefixes = Object.keys(config.customTags)
+  const customTagPrefixes = Object.keys(config.customTags);
 
   if (config.plugins) {
     for (let i = 0; i < config.plugins.length; i++) {
@@ -139,12 +139,16 @@ export function parse(this: Eta, str: string): Array<AstObject> {
 
         trimLeftOfNextStr = closeTag[2];
 
-        let currentType = "";
-        if(prefix === config.parse.exec) currentType = "e";
-        else if(prefix === config.parse.interpolate) currentType = "i";
-        else if(prefix === config.parse.raw) currentType = "r";
-        // custom tags
-        else if(customTagPrefixes.includes(prefix)) currentType = prefix;
+        const currentType: string =
+          prefix === parseOptions.exec
+            ? "e"
+            : prefix === parseOptions.raw
+              ? "r"
+              : prefix === parseOptions.interpolate
+                ? "i"
+                : customTagPrefixes.includes(prefix)
+                  ? prefix
+                  : "";
 
         currentObj = { t: currentType, val: content };
         break;

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -499,6 +499,15 @@ describe("customTags", () => {
     expect(res).toEqual("<p>Hello</p>");
   });
 
+  it("throws on conflicting custom tag prefix", () => {
+    expect(() => new Eta({ customTags: { "=": () => "" } })).toThrow(
+      /conflicts with a built-in prefix/,
+    );
+    expect(() => new Eta({ customTags: { "-": () => "" } })).toThrow(
+      /conflicts with a built-in prefix/,
+    );
+  });
+
   it("works alongside built-in tags", () => {
     const eta = new Eta({
       customTags: { "*": (content) => content.trim().toUpperCase() },

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -458,6 +458,60 @@ describe("block", () => {
   });
 });
 
+describe("customTags", () => {
+  it("basic custom tag renders output", () => {
+    const eta = new Eta({
+      customTags: {
+        "*": (content, data) =>
+          (data as Record<string, string>)[content.trim()],
+      },
+    });
+
+    const res = eta.renderString("Hello <%* name %>!", { name: "World" });
+    expect(res).toEqual("Hello World!");
+  });
+
+  it("comment tag that outputs nothing", () => {
+    const eta = new Eta({
+      customTags: { "#": () => "" },
+    });
+
+    const res = eta.renderString("A<%# this is a comment %>B", {});
+    expect(res).toEqual("AB");
+  });
+
+  it("multiple custom tags in one template", () => {
+    const translations: Record<string, Record<string, string>> = {
+      en: { greeting: "Hello" },
+    };
+
+    const eta = new Eta({
+      customTags: {
+        "#": () => "",
+        "*": (key, data) =>
+          translations[(data as { lang: string }).lang][key.trim()],
+      },
+    });
+
+    const res = eta.renderString("<%# comment %><p><%* greeting %></p>", {
+      lang: "en",
+    });
+    expect(res).toEqual("<p>Hello</p>");
+  });
+
+  it("works alongside built-in tags", () => {
+    const eta = new Eta({
+      customTags: { "*": (content) => content.trim().toUpperCase() },
+    });
+
+    const res = eta.renderString("<%= it.a %>|<%* hello %>|<%~ it.b %>", {
+      a: "A",
+      b: "<B>",
+    });
+    expect(res).toEqual("A|HELLO|<B>");
+  });
+});
+
 describe("capture", () => {
   const eta = new Eta();
 


### PR DESCRIPTION
## Summary

- Adds a `customTags` config option for defining custom tag prefixes with handler functions
- Keys are tag prefixes, values are functions that receive the tag content (as a string) and the template data object
- Supersedes #364 by @Tikolu — original commit preserved with cleanup on top

## Usage

```js
const translations = {
  en: { greeting: "Hello!" },
  pl: { greeting: "Cześć!" },
};

const eta = new Eta({
  customTags: {
    "#": () => "",  // comment tag
    "*": (key, data) => translations[data.lang][key.trim()],
  },
});

eta.renderString("<%# comment %><p><%* greeting %></p>", { lang: "en" });
// => "<p>Hello!</p>"
```

## Changes

- `src/config.ts` — add `customTags` to `EtaConfig` with default `{}`
- `src/parse.ts` — include custom tag prefixes in the parser regex, set tag type to the prefix string
- `src/compile-string.ts` — dispatch custom tag types in `compileBody` via `this.config.customTags`
- `test/render.spec.ts` — 4 tests (basic lookup, comment, multiple tags, mixed with built-in tags)

## Test plan

- [x] Full suite (106 tests) passing
- [x] `pnpm format`, `pnpm lint`, `pnpm build` all clean

Closes #364